### PR TITLE
Throw an error if -1 is used

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -228,7 +228,7 @@ CronExpression._parseField = function(field, value, constraints) {
       var atoms = val.split('-');
 
       // Validate format
-      if (atoms.length > 2) {
+      if (atoms.length != 2) {
         throw new Error('Invalid range format: ' + val);
       }
 
@@ -236,7 +236,8 @@ CronExpression._parseField = function(field, value, constraints) {
       var min = parseInt(atoms[0], 10);
       var max = parseInt(atoms[1], 10);
 
-      if (min < constraints[0] || max > constraints[1]) {
+      if (Number.isNaN(min) || Number.isNaN(max) ||
+          min < constraints[0] || max > constraints[1]) {
         throw new Error(
           'Constraint error, got range ' +
           min + '-' + max +
@@ -460,7 +461,7 @@ CronExpression.prototype.reset = function() {
  * @public
  * @param  {String}   expression   Input expression
  * @param  {Object}   [options]  Parsing options
- * @param  {Function} callback 
+ * @param  {Function} callback
  */
 CronExpression.parse = function(expression, options, callback) {
   if (typeof options === 'function') {

--- a/test/expression.js
+++ b/test/expression.js
@@ -60,6 +60,16 @@ test('second value out of the range', function(t) {
   });
 });
 
+test('second value out of the range', function(t) {
+  CronExpression.parse('-1 * * * * *', function(err, interval) {
+    console.log('Error', err);
+    t.ok(err, 'Error expected');
+    t.equal(interval, undefined, 'No interval iterator expected');
+
+    t.end();
+  });
+});
+
 test('minute value out of the range', function(t) {
   CronExpression.parse('* 32,72 * * * *', function(err, interval) {
     t.ok(err, 'Error expected');


### PR DESCRIPTION
If a cron syntax contains -1, expression will be parsed and `next()` will enter into an infinite loop. This pull-request fix this issue.

It also fixes the last test that fails when it runs on a different timezone.
