### PR TITLE
no longer requiring the day string to be the entire string in regex

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -111,7 +111,8 @@ CronExpression._parseField = function(field, value, constraints) {
     case 'dayOfWeek':
       var aliases = CronExpression.aliases[field];
 
-      value = value.replace(/^[a-z]{1,3}$/gi, function(match) {
+      value = value.replace(/[a-z]{1,3}/gi, function(match) {
+        match = match.toLowerCase();
         if (aliases[match]) {
           return aliases[match];
         } else {

--- a/test/expression.js
+++ b/test/expression.js
@@ -317,3 +317,50 @@ test('expression limited with start and end date', function(t) {
   });
 });
 
+test('expression using days of week strings', function(t) {
+  CronExpression.parse('15 10 * * MON-TUE', function(err, interval) {
+    t.ifError(err, 'Interval parse error');
+    t.ok(interval, 'Interval parsed');
+
+    var intervals = interval.iterate(8);
+    t.ok(intervals, 'Found intervals');
+
+    for (var i = 0, c = intervals.length; i < c; i++) {
+      var next = intervals[i];
+      var day = next.getDay();
+
+      t.ok(next, 'Found next scheduled interval');
+      t.ok(day == 1 || day == 2, "Day matches")
+      t.equal(next.getHours(), 10, 'Hour matches');
+      t.equal(next.getMinutes(), 15, 'Minute matches');
+    }
+
+    t.end();
+  });
+});
+
+test('expression using mixed days of week strings', function(t) {
+  CronExpression.parse('15 10 * jAn-FeB mOn-tUE', function(err, interval) {
+    t.ifError(err, 'Interval parse error');
+    t.ok(interval, 'Interval parsed');
+
+    var intervals = interval.iterate(8);
+    t.ok(intervals, 'Found intervals');
+
+    for (var i = 0, c = intervals.length; i < c; i++) {
+      var next = intervals[i];
+      var day = next.getDay();
+      var month = next.getMonth();
+
+      t.ok(next, 'Found next scheduled interval');
+      t.ok(month == 0 || month == 2, "Month Matches");
+      t.ok(day == 1 || day == 2, "Day matches");
+      t.equal(next.getHours(), 10, 'Hour matches');
+      t.equal(next.getMinutes(), 15, 'Minute matches');
+    }
+
+    t.end();
+  });
+});
+
+


### PR DESCRIPTION
fixes #12 
the regex was doing a replace if the string with 3 characters long.  that was failing when using expression like:
mon-wed
jan-april
