### PR TITLE
Fix Sunday: Ensure key exists while allowing zeros

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -115,7 +115,7 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
       value = value.replace(/[a-z]{1,3}/gi, function(match) {
         match = match.toLowerCase();
 
-        if (aliases[match]) {
+        if (typeof aliases[match] !== "undefined") {
           return aliases[match];
         } else {
           throw new Error('Cannot resolve alias "' + match + '"')


### PR DESCRIPTION
Ran into this problem where Sundays were being evaluated to false because `sun === 0` in the `dayOfWeek` object.
