### PR TITLE
Support 7 as valid day of the week

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Supported format
 *    *    *    *    *    *
 ┬    ┬    ┬    ┬    ┬    ┬
 │    │    │    │    │    |
-│    │    │    │    │    └ day of week (0 - 6)
+│    │    │    │    │    └ day of week (0 - 7) (0 or 7 is Sun)
 │    │    │    │    └───── month (1 - 12)
 │    │    │    └────────── day of month (1 - 31)
 │    │    └─────────────── hour (0 - 23)
@@ -39,7 +39,7 @@ var parser = require('cron-parser');
 
 try {
   var interval = parser.parseExpression('*/2 * * * *');
-  
+
   console.log('Date: ', interval.next()); // Sat Dec 29 2012 00:42:00 GMT+0200 (EET)
   console.log('Date: ', interval.next()); // Sat Dec 29 2012 00:44:00 GMT+0200 (EET)
 } catch (err) {
@@ -60,7 +60,7 @@ var options = {
 
 try {
   var interval = parser.parseExpression('*/22 * * * *', options);
-  
+
   while (true) {
     try {
   		console.log(interval.next());

--- a/lib/expression.js
+++ b/lib/expression.js
@@ -56,7 +56,7 @@ CronExpression.constraints = [
   [ 0, 23 ], // Hour
   [ 1, 31 ], // Day of month
   [ 1, 12 ], // Month
-  [ 0, 6 ] // Day of week
+  [ 0, 7 ] // Day of week
 ];
 
 /**
@@ -165,6 +165,10 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
             );
           }
 
+          if (field == 'dayOfWeek') {
+            value = value % 7;
+          }
+
           if (value > max) {
             stack.push(value);
           }
@@ -180,6 +184,10 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
             'Constraint error, got value ' + result + ' expected range ' +
             constraints[0] + '-' + constraints[1]
           );
+        }
+
+        if (field == 'dayOfWeek') {
+          result = result % 7;
         }
 
         if (result > max) {
@@ -305,6 +313,7 @@ CronExpression._isWildcardRange = function _isWildcardRange (range, constraints)
  * @private
  */
 CronExpression._matchSchedule = function matchSchedule (value, sequence) {
+
   for (var i = 0, c = sequence.length; i < c; i++) {
     if (sequence[i] >= value) {
       return sequence[i] === value;

--- a/test/expression.js
+++ b/test/expression.js
@@ -62,7 +62,6 @@ test('second value out of the range', function(t) {
 
 test('second value out of the range', function(t) {
   CronExpression.parse('-1 * * * * *', function(err, interval) {
-    console.log('Error', err);
     t.ok(err, 'Error expected');
     t.equal(interval, undefined, 'No interval iterator expected');
 
@@ -413,6 +412,122 @@ test('Summertime bug test', function(t) {
     // Before fix the bug it was getting a timeout error if you are
     // in a timezone that changes the DST to ST in the hour 00:00h.
     t.ok(next, 'Found next scheduled interval');
+
+    t.end();
+  });
+});
+
+test('day of month and week are both set and dow is 7', function(t) {
+  CronExpression.parse('10 2 12 8 7', function(err, interval) {
+    t.ifError(err, 'Interval parse error');
+    t.ok(interval, 'Interval parsed');
+
+    var next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getDay(), 0, 'Day matches');
+    t.equal(next.getMonth(), 7, 'Month matches');
+    t.equal(next.getDate(), 2, 'Day of month matches');
+
+    next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getDay(), 0, 'Day matches');
+    t.equal(next.getMonth(), 7, 'Month matches');
+    t.equal(next.getDate(), 9, 'Day of month matches');
+
+    next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getDay(), 3, 'Day matches');
+    t.equal(next.getMonth(), 7, 'Month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
+
+    next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getDay(), 0, 'Day matches');
+    t.equal(next.getMonth(), 7, 'Month matches');
+    t.equal(next.getDate(), 16, 'Day of month matches');
+
+    t.end();
+  });
+});
+
+test('day of month and week are both set and dow is 6,0', function(t) {
+  CronExpression.parse('10 2 12 8 6,0', function(err, interval) {
+    t.ifError(err, 'Interval parse error');
+    t.ok(interval, 'Interval parsed');
+
+    var next = interval.next();
+
+    console.error(next);
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getDay(), 6, 'Day matches');
+    t.equal(next.getMonth(), 7, 'Month matches');
+    t.equal(next.getDate(), 1, 'Day of month matches');
+
+    next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getDay(), 6, 'Day matches');
+    t.equal(next.getMonth(), 7, 'Month matches');
+    t.equal(next.getDate(), 8, 'Day of month matches');
+
+    next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getDay(), 3, 'Day matches');
+    t.equal(next.getMonth(), 7, 'Month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
+
+    // next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getDay(), 3, 'Day matches');
+    t.equal(next.getMonth(), 7, 'Month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
+
+    t.end();
+  });
+});
+
+
+test('day of month and week are both set and dow is 6-7', function(t) {
+  CronExpression.parse('10 2 12 8 6-7', function(err, interval) {
+    t.ifError(err, 'Interval parse error');
+    t.ok(interval, 'Interval parsed');
+
+    var next = interval.next();
+
+    console.error(next);
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getDay(), 6, 'Day matches');
+    t.equal(next.getMonth(), 7, 'Month matches');
+    t.equal(next.getDate(), 1, 'Day of month matches');
+
+    next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getDay(), 6, 'Day matches');
+    t.equal(next.getMonth(), 7, 'Month matches');
+    t.equal(next.getDate(), 8, 'Day of month matches');
+
+    next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getDay(), 3, 'Day matches');
+    t.equal(next.getMonth(), 7, 'Month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
+
+    // next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getDay(), 3, 'Day matches');
+    t.equal(next.getMonth(), 7, 'Month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
 
     t.end();
   });


### PR DESCRIPTION
- As an alias for Sunday, as defined in http://crontab.org/:
  
  `day of week    0-7 (0 or 7 is Sun, or use names)`
