### PR TITLE
adds current version of nodejs and iojs to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js: 
+  - "0.12"
   - "0.11"
   - "0.10"
+  - "iojs"


### PR DESCRIPTION
Since the current version of node is now 0.12 cron-parser should be testing against that now, and since everything passes for the current version of iojs I've added that as well. Tested on travis using my fork (see below).

![screen shot 2015-03-04 at 5 30 34 pm](https://cloud.githubusercontent.com/assets/3527123/6489192/5be03e70-c294-11e4-88c1-14a7c5135e32.png)
