### PR TITLE
src: fix Date.addMonth

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -16,11 +16,11 @@ Date.prototype.addYear = function addYear () {
  * Increment month
  */
 Date.prototype.addMonth = function addMonth () {
-  this.setMonth(this.getMonth() + 1);
   this.setDate(1);
   this.setHours(0);
   this.setMinutes(0);
   this.setSeconds(0);
+  this.setMonth(this.getMonth() + 1);
 };
 
 /**


### PR DESCRIPTION
- Adding 1 month from the 31st day of a month that is followed by a less than
  31-day month, sets the Date to the first day if the following following month.
  For example: if the base Date is the 31st of May, calling addMonth, sets the
  date to the 1st of July instead of the 1st of June.