### PR TITLE
Fix issue with "Sun" value.

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -135,7 +135,7 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
       value = value.replace(/[a-z]{1,3}/gi, function(match) {
         match = match.toLowerCase();
 
-        if (aliases[match]) {
+        if (typeof aliases[match] !== undefined) {
           return aliases[match];
         } else {
           throw new Error('Cannot resolve alias "' + match + '"')

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "Alex Kit <alex.kit@atmajs.com>",
     "Santiago Gimeno <santiago.gimeno@gmail.com>",
     "Daniel <darc.tec@gmail.com>",
-    "Christian Steininger<christian.steininger.cs@gmail.com>"
+    "Christian Steininger<christian.steininger.cs@gmail.com>",
+    "Mykola Piskovyi <m.piskovyi@gmail.com>"
   ],
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Example: "0 15 10 * * Sun" was read as invalid because of "Sun" is 0.