### PR TITLE
Fix matching for Day and WeekDay according to calendar

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -393,6 +393,12 @@ CronExpression.prototype._findSchedule = function _findSchedule () {
       }
     }
 
+    // Add day if select day not match with month (according to calendar)
+    if (!dayOfMonthMatch || !dayOfWeekMatch) {
+      currentDate.addDay();
+      continue;
+    }
+
     // Add day if not day of month is set (and no match) and day of week is wildcard
     if (!isDayOfMonthWildcardMatch && isDayOfWeekWildcardMatch && !dayOfMonthMatch) {
       currentDate.addDay();

--- a/test/expression.js
+++ b/test/expression.js
@@ -654,6 +654,39 @@ test('day of month and week are both set and dow is 6-7', function(t) {
   t.end();
 });
 
+test('day and date in week should matches', function(t){
+  try {
+    var interval = CronExpression.parse('0 1 1 1 * 1');
+    t.ok(interval, 'Interval parsed');
+
+    var next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getHours(), 1, 'Hours matches');
+    t.equal(next.getDay(), 1, 'Day matches');
+    t.equal(next.getDate(), 1, 'Day of month matches');
+
+    next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getHours(), 1, 'Hours matches');
+    t.equal(next.getDay(), 1, 'Day matches');
+    t.equal(next.getDate(), 1, 'Day of month matches');
+
+    next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getHours(), 1, 'Hours matches');
+    t.equal(next.getDay(), 1, 'Day matches');
+    t.equal(next.getDate(), 1, 'Day of month matches');
+
+  } catch (err) {
+    t.ifError(err, 'Interval parse error');
+  }
+
+  t.end();
+});
+
 test('day of month value can\'t be larger than days in month maximum value if it\'s defined explicitly', function(t) {
   try {
     var interval = CronExpression.parse('0 4 30 2 *');

--- a/test/expression.js
+++ b/test/expression.js
@@ -145,7 +145,7 @@ test('fixed expression test', function(t) {
     t.ok(next, 'Found next scheduled interval');
     t.equal(next.getDay(), 0, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 2, 'Day of month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
     t.equal(next.getHours(), 2, 'Hour matches');
     t.equal(next.getMinutes(), 10, 'Minute matches');
   } catch (err) {
@@ -235,7 +235,7 @@ test('range test with iterator', function(t) {
       t.ok(next, 'Found next scheduled interval');
       t.equal(next.getDay(), 0, 'Day matches');
       t.equal(next.getMonth(), 7, 'Month matches');
-      t.equal(next.getDate(), 2, 'Day of month matches');
+      t.equal(next.getDate(), 12, 'Day of month matches');
       t.equal(next.getHours(), 2, 'Hour matches');
       t.equal(next.getMinutes(), 10 + i, 'Minute matches');
     }
@@ -260,7 +260,7 @@ test('incremental range test with iterator', function(t) {
       t.ok(next, 'Found next scheduled interval');
       t.equal(next.getDay(), 0, 'Day matches');
       t.equal(next.getMonth(), 7, 'Month matches');
-      t.equal(next.getDate(), 2, 'Day of month matches');
+      t.equal(next.getDate(), 12, 'Day of month matches');
       t.equal(next.getHours(), 2, 'Hour matches');
       t.equal(next.getMinutes(), 10 + (i * 2), 'Minute matches');
     }
@@ -489,19 +489,12 @@ test('day of month and week are both set', function(t) {
     t.ok(next, 'Found next scheduled interval');
     t.equal(next.getDay(), 0, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 2, 'Day of month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
     t.equal(next.getDay(), 0, 'Day matches');
-    t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 9, 'Day of month matches');
-
-    next = interval.next();
-
-    t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 3, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
     t.equal(next.getDate(), 12, 'Day of month matches');
 
@@ -510,7 +503,14 @@ test('day of month and week are both set', function(t) {
     t.ok(next, 'Found next scheduled interval');
     t.equal(next.getDay(), 0, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 16, 'Day of month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
+
+    next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getDay(), 0, 'Day matches');
+    t.equal(next.getMonth(), 7, 'Month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
   } catch (err) {
     t.ifError(err, 'Interval parse error');
   }
@@ -546,19 +546,12 @@ test('day of month and week are both set and dow is 7', function(t) {
     t.ok(next, 'Found next scheduled interval');
     t.equal(next.getDay(), 0, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 2, 'Day of month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
     t.equal(next.getDay(), 0, 'Day matches');
-    t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 9, 'Day of month matches');
-
-    next = interval.next();
-
-    t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 3, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
     t.equal(next.getDate(), 12, 'Day of month matches');
 
@@ -567,7 +560,14 @@ test('day of month and week are both set and dow is 7', function(t) {
     t.ok(next, 'Found next scheduled interval');
     t.equal(next.getDay(), 0, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 16, 'Day of month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
+
+    next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getDay(), 0, 'Day matches');
+    t.equal(next.getMonth(), 7, 'Month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
   } catch (err) {
     t.ifError(err, 'Interval parse error');
   }
@@ -585,26 +585,26 @@ test('day of month and week are both set and dow is 6,0', function(t) {
     t.ok(next, 'Found next scheduled interval');
     t.equal(next.getDay(), 6, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 1, 'Day of month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
     t.equal(next.getDay(), 6, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 8, 'Day of month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 3, 'Day matches');
+    t.equal(next.getDay(), 6, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
     t.equal(next.getDate(), 12, 'Day of month matches');
 
     // next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 3, 'Day matches');
+    t.equal(next.getDay(), 6, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
     t.equal(next.getDate(), 12, 'Day of month matches');
   } catch (err) {
@@ -625,26 +625,26 @@ test('day of month and week are both set and dow is 6-7', function(t) {
     t.ok(next, 'Found next scheduled interval');
     t.equal(next.getDay(), 6, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 1, 'Day of month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
     t.equal(next.getDay(), 6, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 8, 'Day of month matches');
+    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 3, 'Day matches');
+    t.equal(next.getDay(), 6, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
     t.equal(next.getDate(), 12, 'Day of month matches');
 
     // next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 3, 'Day matches');
+    t.equal(next.getDay(), 6, 'Day matches');
     t.equal(next.getMonth(), 7, 'Month matches');
     t.equal(next.getDate(), 12, 'Day of month matches');
   } catch (err) {


### PR DESCRIPTION
Fix issue with wrong schedule time (date and day in month calendar) according to CRON.
For example: `0 1 1 1 * 1` means to run at `01:01 1 DATE of ANY month on MONDAY` any year.
If calc from today, and according to calendar this date should be `01:01 Mon Feb 01 2016`, instead of wrong `01:01 Jul 27 2015`.
Current fix resolve this problem.

And after this, I notice "broken" test. As I see, test also was a little bit wrong, for check days.
Let's figure out with this:
`10 2 12 8 0` means to run **only** at `02:10 12 Aug on Sunday` any year.
For some reason, in tests was wrong date numbers.
So for current CRON next run times are:
02:10 12 Aug on Sun 2018
02:10 12 Aug on Sun 2029
02:10 12 Aug on Sun 2035

Same behaviour in test for other CRON samples.
For any case, if there some doubts, You can check it with calendar.

Thanks.

PS. For now, for same CRON value, calculation "next run time" on JS (node module) match with "next run time" with JAVA Spring Framework.