### PR TITLE
Validate repeat interval value - 0 or negative should not be allowed.

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -279,7 +279,11 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
       }
 
       // Create range
-      var repeatIndex = repeatInterval;
+      var repeatIndex = +repeatInterval;
+
+      if (Number.isNaN(repeatIndex) || repeatIndex <= 0) {
+        throw new Error('Constraint error, cannot repeat at every ' + repeatIndex + ' time.');
+      }
 
       for (var index = min, count = max; index <= count; index++) {
         if (repeatIndex > 0 && (repeatIndex % repeatInterval) === 0) {

--- a/test/expression.js
+++ b/test/expression.js
@@ -769,7 +769,6 @@ test('Must not parse an expression which has repeat 0 times', function(t) {
   try {
     var expression = CronExpression.parse('0 */0 * * *');
     var val = expression.next();
-    t.notOk(val);
   } catch (err) {
     t.ok(err, 'Error expected');
     t.equal(err.message, 'Constraint error, cannot repeat at every 0 time.');
@@ -782,7 +781,6 @@ test('Must not parse an expression which has repeat negative number times', func
   try {
     var expression = CronExpression.parse('0 */-5 * * *');
     var val = expression.next();
-    t.notOk(val);
   } catch (err) {
     t.ok(err, 'Error expected');
     t.equal(err.message, 'Constraint error, cannot repeat at every -5 time.');

--- a/test/expression.js
+++ b/test/expression.js
@@ -764,3 +764,29 @@ test('valid ES6 iterator should be returned if iterator options is set to true',
 
   t.end();
 });
+
+test('Must not parse an expression which has repeat 0 times', function(t) {
+  try {
+    var expression = CronExpression.parse('0 */0 * * *');
+    var val = expression.next();
+    t.notOk(val);
+  } catch (err) {
+    t.ok(err, 'Error expected');
+    t.equal(err.message, 'Constraint error, cannot repeat at every 0 time.');
+  }
+
+  t.end();
+});
+
+test('Must not parse an expression which has repeat negative number times', function(t) {
+  try {
+    var expression = CronExpression.parse('0 */-5 * * *');
+    var val = expression.next();
+    t.notOk(val);
+  } catch (err) {
+    t.ok(err, 'Error expected');
+    t.equal(err.message, 'Constraint error, cannot repeat at every -5 time.');
+  }
+
+  t.end();
+});


### PR DESCRIPTION
Thanks for your great work and library. Here's a minor issue i've encountered today and tried to fix appropriately.

When you create an invalid expression of the kind:
 
- 0 */0 * * *
- 0 */-1 * * *

Currently the cron-parser can parse the expression. Whenever you call .next() it enters an infinite while loop and the process dies. Can be reproduced with both tests included and the current version of the cron-parser. After the fix, whenever you try to parse this expression a Constraint error will be thrown.