### PR TITLE
Added fs:false block for more friendly browser usage with Webpack 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   },
   "engines": {
     "node": ">=0.8"
+  },
+  "browser": {
+    "fs": false
   }
 }


### PR DESCRIPTION
Resolves #49

This prevents Webpack from trying to pull in the `fs` module when in a browser context.