### PR TITLE
Support tab separator.

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -579,7 +579,7 @@ CronExpression.parse = function parse (expression, options, callback) {
 
     // Split fields
     var fields = [];
-    var atoms = expression.split(' ');
+    var atoms = expression.split(/\t| /);
 
     // Resolve fields
     var start = (CronExpression.map.length - atoms.length);

--- a/test/expression.js
+++ b/test/expression.js
@@ -42,6 +42,26 @@ test('default expression test', function(t) {
   t.end();
 });
 
+test('default expression (tab separate) test', function(t) {
+  try {
+    var interval = CronExpression.parse('*	*	*	*	*');
+    t.ok(interval, 'Interval parsed');
+
+    var date = new CronDate();
+    date.addMinute();
+
+    var next = interval.next();
+
+    t.ok(next, 'Found next scheduled interval');
+    t.equal(next.getMinutes(), date.getMinutes(), 'Schedule matches');
+
+  } catch (err) {
+    t.ifError(err, 'Interval parse error');
+  }
+
+  t.end();
+});
+
 test('second value out of the range', function(t) {
   try {
     CronExpression.parse('61 * * * * *');


### PR DESCRIPTION
This PR provides to support tab(`\t`) separator.

I think some cron string uses `\t` to separate fields. But this module can not split tab, so I call `replace("\t", " ")` before call CronExpression.parse every time.
