### PR TITLE
RFC: Add timezone support to CronDate

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ cron-parser
 [![Build Status](https://travis-ci.org/harrisiirak/cron-parser.png?branch=master)](https://travis-ci.org/harrisiirak/cron-parser)
 [![NPM version](https://badge.fury.io/js/cron-parser.png)](http://badge.fury.io/js/cron-parser)
 
-Node.js library for parsing crontab instructions
+Node.js library for parsing crontab instructions. It includes support for timezones and DST transitions.
 
 Setup
 ========
@@ -84,10 +84,44 @@ try {
 
 ```
 
+Timezone support
+
+```javascript
+var parser = require('cron-parser');
+
+var options = {
+  currentDate: '2016-03-27 00:00:01',
+  tz: 'Europe/Athens'
+};
+
+try {
+  var interval = CronExpression.parse('0 * * * *', options);
+
+  console.log('Date: ', interval.next().toString()); // Date:  Sun Mar 27 2016 01:00:00 GMT+0200
+  console.log('Date: ', interval.next().toString()); // Date:  Sun Mar 27 2016 02:00:00 GMT+0200
+  console.log('Date: ', interval.next().toString()); // Date:  Sun Mar 27 2016 04:00:00 GMT+0300 (Notice DST transition)
+} catch (err) {
+  console.log('Error: ' + err.message);
+}
+```
+
 Options
 ========
 
 * *currentDate* - Start date of the iteration
 * *endDate* - End date of the iteration
+
+`currentDate` and `endDate` accept `string`, `integer` and `Date` as input.
+
+In case of using `string` as input, not every string format accepted
+by the `Date` constructor will work correctly. The supported formats are: [`ISO8601`](http://momentjs.com/docs/#/parsing/string/) and the older
+[`ASP.NET JSON Date`](http://momentjs.com/docs/#/parsing/asp-net-json-date/) format. The reason being that those are the formats accepted by the
+[`moment`](http://momentjs.com) library which is being used to handle dates.
+
+Using `Date` as an input can be problematic specially when using the `tz` option. The issue being that, when creating a new `Date` object without
+any timezone information, it will be created in the timezone of the system that is running the code. This (most of times) won't be what the user
+will be expecting. Using one of the supported `string` formats will solve the issue(see timezone example).
+
 * *iterator* - Return ES6 compatible iterator object 
 * *utc* - Enable UTC
+* *tz* - Timezone string

--- a/lib/date.js
+++ b/lib/date.js
@@ -1,79 +1,141 @@
 'use strict';
 
-/**
- * Date class extension methods
- */
-var extensions = {
-  addYear: function addYear() {
-    this.setFullYear(this.getFullYear() + 1);
-  },
+var moment = require('moment-timezone');
 
-  addMonth: function addMonth() {
-    this.setDate(1);
-    this.setHours(0);
-    this.setMinutes(0);
-    this.setSeconds(0);
-    this.setMonth(this.getMonth() + 1);
-  },
-
-  addDay: function addDay() {
-    var day = this.getDate();
-    this.setDate(day + 1);
-
-    this.setHours(0);
-    this.setMinutes(0);
-    this.setSeconds(0);
-
-    if (this.getDate() === day) {
-      this.setDate(day + 2);
-    }
-  },
-
-  addHour: function addHour() {
-    var hours = this.getHours();
-    this.setHours(hours + 1);
-
-    if (this.getHours() === hours) {
-      this.setHours(hours + 2);
-    }
-
-    this.setMinutes(0);
-    this.setSeconds(0);
-  },
-
-  addMinute: function addMinute() {
-    this.setMinutes(this.getMinutes() + 1);
-    this.setSeconds(0);
-  },
-
-  addSecond: function addSecond() {
-    this.setSeconds(this.getSeconds() + 1);
-  },
-
-  toUTC: function toUTC() {
-    var to = new CronDate(this);
-    var ms = to.getTime() + (to.getTimezoneOffset() * 60000);
-    to.setTime(ms);
-    return to;
-  }
+CronDate.prototype.addYear = function() {
+  this.date.add(1, 'year');
 };
 
-/**
- * Extends Javascript Date class by adding
- * utility methods for basic date incrementation
- */
+CronDate.prototype.addMonth = function() {
+  this.date.add(1, 'month').startOf('month');
+};
 
-function CronDate (timestamp) {
-  var date = timestamp ? new Date(timestamp) : new Date();
+CronDate.prototype.addDay = function() {
+  this.date.add(1, 'day').startOf('day');
+};
 
-  // Attach extensions
-  var methods = Object.keys(extensions);
-  for (var i = 0, c = methods.length; i < c; i++) {
-    var method = methods[i];
-    date[method] = extensions[method].bind(date);
+CronDate.prototype.addHour = function() {
+  this.date.add(1, 'hour').startOf('hour');
+};
+
+CronDate.prototype.addMinute = function() {
+  this.date.add(1, 'minute').startOf('minute');
+};
+
+CronDate.prototype.addSecond = function() {
+  this.date.add(1, 'second').startOf('second');
+};
+
+CronDate.prototype.getDate = function() {
+  return this.date.date();
+};
+
+CronDate.prototype.getFullYear = function() {
+  return this.date.year();
+};
+
+CronDate.prototype.getDay = function() {
+  return this.date.day();
+};
+
+CronDate.prototype.getMonth = function() {
+  return this.date.month();
+};
+
+CronDate.prototype.getHours = function() {
+  return this.date.hours();
+};
+
+CronDate.prototype.getMinutes = function() {
+  return this.date.minute();
+};
+
+CronDate.prototype.getSeconds = function() {
+  return this.date.second();
+};
+
+CronDate.prototype.getTime = function() {
+  return this.date.valueOf();
+};
+
+CronDate.prototype.getUTCDate = function() {
+  return this._getUTC().date();
+};
+
+CronDate.prototype.getUTCFullYear = function() {
+  return this._getUTC().year();
+};
+
+CronDate.prototype.getUTCDay = function() {
+  return this._getUTC().day();
+};
+
+CronDate.prototype.getUTCMonth = function() {
+  return this._getUTC().month();
+};
+
+CronDate.prototype.getUTCHours = function() {
+  return this._getUTC().hours();
+};
+
+CronDate.prototype.getUTCMinutes = function() {
+  return this._getUTC().minute();
+};
+
+CronDate.prototype.getUTCSeconds = function() {
+  return this._getUTC().second();
+};
+
+CronDate.prototype.setDate = function(d) {
+  return this.date.date(d);
+};
+
+CronDate.prototype.setFullYear = function(y) {
+  return this.date.year(y);
+};
+
+CronDate.prototype.setDay = function(d) {
+  return this.date.day(d);
+};
+
+CronDate.prototype.setMonth = function(m) {
+  return this.date.month(m);
+};
+
+CronDate.prototype.setHours = function(h) {
+  return this.date.hour(h);
+};
+
+CronDate.prototype.setMinutes = function(m) {
+  return this.date.minute(m);
+};
+
+CronDate.prototype.setSeconds = function(s) {
+  return this.date.second(s);
+};
+
+CronDate.prototype.getTime = function() {
+  return this.date.valueOf();
+};
+
+CronDate.prototype._getUTC = function() {
+  return moment.utc(this.date);
+};
+
+CronDate.prototype.toString = function() {
+  return this.date.toString();
+};
+
+function CronDate (timestamp, tz) {
+  if (timestamp instanceof CronDate) {
+    timestamp = timestamp.date;
   }
 
-  return date;
+  if (!tz) {
+    this.date = moment(timestamp);
+  } else {
+    this.date = moment.tz(timestamp, tz);
+  }
 }
 
 module.exports = CronDate;

--- a/lib/date.js
+++ b/lib/date.js
@@ -132,6 +132,10 @@ function CronDate (timestamp, tz) {
   }
 
   if (!tz) {
+    if (timestamp && typeof timestamp !== 'number') {
+      timestamp = Date.parse(timestamp);
+    }
+
     this._date = moment(timestamp);
   } else {
     this._date = moment.tz(timestamp, tz);

--- a/lib/date.js
+++ b/lib/date.js
@@ -132,10 +132,6 @@ function CronDate (timestamp, tz) {
   }
 
   if (!tz) {
-    if (timestamp && typeof timestamp !== 'number') {
-      timestamp = Date.parse(timestamp);
-    }
-
     this._date = moment(timestamp);
   } else {
     this._date = moment.tz(timestamp, tz);

--- a/lib/date.js
+++ b/lib/date.js
@@ -3,59 +3,59 @@
 var moment = require('moment-timezone');
 
 CronDate.prototype.addYear = function() {
-  this.date.add(1, 'year');
+  this._date.add(1, 'year');
 };
 
 CronDate.prototype.addMonth = function() {
-  this.date.add(1, 'month').startOf('month');
+  this._date.add(1, 'month').startOf('month');
 };
 
 CronDate.prototype.addDay = function() {
-  this.date.add(1, 'day').startOf('day');
+  this._date.add(1, 'day').startOf('day');
 };
 
 CronDate.prototype.addHour = function() {
-  this.date.add(1, 'hour').startOf('hour');
+  this._date.add(1, 'hour').startOf('hour');
 };
 
 CronDate.prototype.addMinute = function() {
-  this.date.add(1, 'minute').startOf('minute');
+  this._date.add(1, 'minute').startOf('minute');
 };
 
 CronDate.prototype.addSecond = function() {
-  this.date.add(1, 'second').startOf('second');
+  this._date.add(1, 'second').startOf('second');
 };
 
 CronDate.prototype.getDate = function() {
-  return this.date.date();
+  return this._date.date();
 };
 
 CronDate.prototype.getFullYear = function() {
-  return this.date.year();
+  return this._date.year();
 };
 
 CronDate.prototype.getDay = function() {
-  return this.date.day();
+  return this._date.day();
 };
 
 CronDate.prototype.getMonth = function() {
-  return this.date.month();
+  return this._date.month();
 };
 
 CronDate.prototype.getHours = function() {
-  return this.date.hours();
+  return this._date.hours();
 };
 
 CronDate.prototype.getMinutes = function() {
-  return this.date.minute();
+  return this._date.minute();
 };
 
 CronDate.prototype.getSeconds = function() {
-  return this.date.second();
+  return this._date.second();
 };
 
 CronDate.prototype.getTime = function() {
-  return this.date.valueOf();
+  return this._date.valueOf();
 };
 
 CronDate.prototype.getUTCDate = function() {
@@ -87,54 +87,54 @@ CronDate.prototype.getUTCSeconds = function() {
 };
 
 CronDate.prototype.setDate = function(d) {
-  return this.date.date(d);
+  return this._date.date(d);
 };
 
 CronDate.prototype.setFullYear = function(y) {
-  return this.date.year(y);
+  return this._date.year(y);
 };
 
 CronDate.prototype.setDay = function(d) {
-  return this.date.day(d);
+  return this._date.day(d);
 };
 
 CronDate.prototype.setMonth = function(m) {
-  return this.date.month(m);
+  return this._date.month(m);
 };
 
 CronDate.prototype.setHours = function(h) {
-  return this.date.hour(h);
+  return this._date.hour(h);
 };
 
 CronDate.prototype.setMinutes = function(m) {
-  return this.date.minute(m);
+  return this._date.minute(m);
 };
 
 CronDate.prototype.setSeconds = function(s) {
-  return this.date.second(s);
+  return this._date.second(s);
 };
 
 CronDate.prototype.getTime = function() {
-  return this.date.valueOf();
+  return this._date.valueOf();
 };
 
 CronDate.prototype._getUTC = function() {
-  return moment.utc(this.date);
+  return moment.utc(this._date);
 };
 
 CronDate.prototype.toString = function() {
-  return this.date.toString();
+  return this._date.toString();
 };
 
 function CronDate (timestamp, tz) {
   if (timestamp instanceof CronDate) {
-    timestamp = timestamp.date;
+    timestamp = timestamp._date;
   }
 
   if (!tz) {
-    this.date = moment(timestamp);
+    this._date = moment(timestamp);
   } else {
-    this.date = moment.tz(timestamp, tz);
+    this._date = moment.tz(timestamp, tz);
   }
 }
 

--- a/lib/expression.js
+++ b/lib/expression.js
@@ -306,7 +306,6 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
 };
 
 CronExpression.prototype._applyTimezoneShift = function(currentDate, method) {
-
   var previousHour = currentDate.getHours();
   currentDate[method]();
   var currentHour = currentDate.getHours();

--- a/lib/expression.js
+++ b/lib/expression.js
@@ -17,8 +17,9 @@ var CronDate = require('./date');
  */
 function CronExpression (fields, options) {
   this._options = options;
-  this._currentDate = new CronDate(options.currentDate);
-  this._endDate = options.endDate ? new CronDate(options.endDate) : null;
+  this._tz = options.tz;
+  this._currentDate = new CronDate(options.currentDate, this._tz);
+  this._endDate = options.endDate ? new CronDate(options.endDate, this._tz) : null;
   this._fields = {};
   this._isIterator = options.iterator || false;
   this._hasIterated = false;
@@ -352,7 +353,7 @@ CronExpression.prototype._findSchedule = function _findSchedule () {
     return !this._utc ? name : ('getUTC' + name.slice(3));
   }.bind(this);
 
-  var currentDate = new CronDate(this._currentDate);
+  var currentDate = new CronDate(this._currentDate, this._tz);
   var endDate = this._endDate;
 
   // TODO: Improve this part
@@ -462,7 +463,7 @@ CronExpression.prototype._findSchedule = function _findSchedule () {
   }
 
   // When internal date is not mutated, append one second as a padding
-  var nextDate = new CronDate(currentDate);
+  var nextDate = new CronDate(currentDate, this._tz);
   if (this._currentDate !== currentDate) {
     nextDate.addSecond();
   }
@@ -558,6 +559,7 @@ CronExpression.prototype.reset = function reset () {
  * @param {Function} [callback]
  */
 CronExpression.parse = function parse (expression, options, callback) {
+  var self = this;
   if (typeof options === 'function') {
     callback = options;
     options = {};
@@ -569,7 +571,7 @@ CronExpression.parse = function parse (expression, options, callback) {
     }
 
     if (!options.currentDate) {
-      options.currentDate = new CronDate();
+      options.currentDate = new CronDate(undefined, self._tz);
     }
 
     // Is input expression predefined?

--- a/lib/expression.js
+++ b/lib/expression.js
@@ -305,6 +305,30 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
   return parseSequence(value);
 };
 
+CronExpression.prototype._applyTimezoneShift = function(currentDate, method) {
+
+  var previousHour = currentDate.getHours();
+  currentDate[method]();
+  var currentHour = currentDate.getHours();
+  var diff = currentHour - previousHour;
+  if (diff === 2) {
+    // Starting DST
+    if (this._fields.hour.length !== 24) {
+      // Hour is specified
+      this._dstStart = currentHour;
+    }
+  } else if ((diff === 0) &&
+             (currentDate.getMinutes() === 0) &&
+             (currentDate.getSeconds() === 0)) {
+    // Ending DST
+    if (this._fields.hour.length !== 24) {
+      // Hour is specified
+      this._dstEnd = currentHour;
+    }
+  }
+}
+
+
 /**
  * Find next matching schedule date
  *
@@ -312,28 +336,6 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
  * @private
  */
 CronExpression.prototype._findSchedule = function _findSchedule () {
-
-  function incDateAndCheckDST(currentDate, method) {
-    var previousHour = currentDate.getHours();
-    currentDate[method]();
-    currentHour = currentDate.getHours();
-    var diff = currentHour - previousHour;
-    if (diff === 2) {
-      // Starting DST
-      if (this._fields.hour.length !== 24) {
-        // Hour is specified
-        this.dstStart = currentHour;
-      }
-    } else if ((diff === 0) &&
-               (currentDate.getMinutes() === 0) &&
-               (currentDate.getSeconds() === 0)) {
-      // Ending DST
-      if (this._fields.hour.length !== 24) {
-        // Hour is specified
-        this.dstEnd = currentHour;
-      }
-    }
-  }
 
   /**
    * Match field value
@@ -385,9 +387,6 @@ CronExpression.prototype._findSchedule = function _findSchedule () {
     currentDate.addSecond();
   }
 
-  var previousHour;
-  var currentHour;
-
   // Find matching schedule
   while (true) {
     // Validate timespan
@@ -412,6 +411,8 @@ CronExpression.prototype._findSchedule = function _findSchedule () {
     var isDayOfMonthWildcardMatch = isWildcardRange(this._fields.dayOfMonth, CronExpression.constraints[3]);
     var isMonthWildcardMatch = isWildcardRange(this._fields.month, CronExpression.constraints[4]);
     var isDayOfWeekWildcardMatch = isWildcardRange(this._fields.dayOfWeek, CronExpression.constraints[5]);
+
+    var currentHour = currentDate[method('getHours')]();
 
     // Validate days in month if explicit value is given
     if (!isMonthWildcardMatch) {
@@ -468,29 +469,28 @@ CronExpression.prototype._findSchedule = function _findSchedule () {
     }
 
     // Match hour
-    var currentHour = currentDate[method('getHours')]();
     if (!matchSchedule(currentHour, this._fields.hour)) {
-      if (this.dstStart !== currentHour) {
-        this.dstStart = null;
-        incDateAndCheckDST.call(this, currentDate, 'addHour');
+      if (this._dstStart !== currentHour) {
+        this._dstStart = null;
+        this._applyTimezoneShift(currentDate, 'addHour');
         continue;
-      } 
-    } else if (this.dstEnd === currentHour) {
-      this.dstEnd = null;
-      incDateAndCheckDST.call(this, currentDate, 'addHour');
+      }
+    } else if (this._dstEnd === currentHour) {
+      this._dstEnd = null;
+      this._applyTimezoneShift(currentDate, 'addHour');
       continue;
     }
 
 
     // Match minute
     if (!matchSchedule(currentDate[method('getMinutes')](), this._fields.minute)) {
-      incDateAndCheckDST.call(this, currentDate, 'addMinute');
+      this._applyTimezoneShift(currentDate, 'addMinute');
       continue;
     }
 
     // Match second
     if (!matchSchedule(currentDate[method('getSeconds')](), this._fields.second)) {
-      incDateAndCheckDST.call(this, currentDate, 'addSecond');
+      this._applyTimezoneShift(currentDate, 'addSecond');
       continue;
     }
 

--- a/lib/expression.js
+++ b/lib/expression.js
@@ -312,6 +312,29 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
  * @private
  */
 CronExpression.prototype._findSchedule = function _findSchedule () {
+
+  function incDateAndCheckDST(currentDate, method) {
+    var previousHour = currentDate.getHours();
+    currentDate[method]();
+    currentHour = currentDate.getHours();
+    var diff = currentHour - previousHour;
+    if (diff === 2) {
+      // Starting DST
+      if (this._fields.hour.length !== 24) {
+        // Hour is specified
+        this.dstStart = currentHour;
+      }
+    } else if ((diff === 0) &&
+               (currentDate.getMinutes() === 0) &&
+               (currentDate.getSeconds() === 0)) {
+      // Ending DST
+      if (this._fields.hour.length !== 24) {
+        // Hour is specified
+        this.dstEnd = currentHour;
+      }
+    }
+  }
+
   /**
    * Match field value
    *
@@ -348,7 +371,7 @@ CronExpression.prototype._findSchedule = function _findSchedule () {
 
     return range.length === (constraints[1] - (constraints[0] < 1 ? - 1 : 0));
   }
-  
+
   var method = function(name) {
     return !this._utc ? name : ('getUTC' + name.slice(3));
   }.bind(this);
@@ -361,6 +384,9 @@ CronExpression.prototype._findSchedule = function _findSchedule () {
   if (this._fields.second.length > 1 && !this._hasIterated) {
     currentDate.addSecond();
   }
+
+  var previousHour;
+  var currentHour;
 
   // Find matching schedule
   while (true) {
@@ -442,20 +468,29 @@ CronExpression.prototype._findSchedule = function _findSchedule () {
     }
 
     // Match hour
-    if (!matchSchedule(currentDate[method('getHours')](), this._fields.hour)) {
-      currentDate.addHour();
+    var currentHour = currentDate[method('getHours')]();
+    if (!matchSchedule(currentHour, this._fields.hour)) {
+      if (this.dstStart !== currentHour) {
+        this.dstStart = null;
+        incDateAndCheckDST.call(this, currentDate, 'addHour');
+        continue;
+      } 
+    } else if (this.dstEnd === currentHour) {
+      this.dstEnd = null;
+      incDateAndCheckDST.call(this, currentDate, 'addHour');
       continue;
     }
 
+
     // Match minute
     if (!matchSchedule(currentDate[method('getMinutes')](), this._fields.minute)) {
-      currentDate.addMinute();
+      incDateAndCheckDST.call(this, currentDate, 'addMinute');
       continue;
     }
 
     // Match second
     if (!matchSchedule(currentDate[method('getSeconds')](), this._fields.second)) {
-      currentDate.addSecond();
+      incDateAndCheckDST.call(this, currentDate, 'addSecond');
       continue;
     }
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "Brian Vaughn <brian.david.vaughn@gmail.com>"
   ],
   "license": "MIT",
+  "dependencies": {
+    "moment-timezone": "^0.5.0"
+  },
   "devDependencies": {
     "tap": "^0.5.0"
   },

--- a/test/31_of_month.js
+++ b/test/31_of_month.js
@@ -6,8 +6,9 @@ test('expression 31 of month', function(t) {
   try {
     var interval = expression.parse('0 0 31 * *');
     var i;
-    for (i = 0; i < 100; ++i) {
-      interval.next();
+    var d;
+    for (i = 0; i < 20; ++i) {
+      d = interval.next();
     }
     t.end();
   } catch (err) {

--- a/test/expression.js
+++ b/test/expression.js
@@ -294,8 +294,8 @@ test('predefined expression', function(t) {
 test('expression limited with start and end date', function(t) {
   try {
     var options = {
-      currentDate: new CronDate('2012-12-26 14:38:53'),
-      endDate: new CronDate('2012-12-26 16:40:00')
+      currentDate: new CronDate('Wed, 26 Dec 2012 14:38:53'),
+      endDate: new CronDate('Wed, 26 Dec 2012 16:40:00')
     };
 
     var interval = CronExpression.parse('*/20 * * * *', options);
@@ -400,7 +400,7 @@ test('expression using days of week strings', function(t) {
 test('expression using mixed days of week strings', function(t) {
   try {
     var options = {
-      currentDate: new CronDate('2012-12-26 14:38:53')
+      currentDate: new CronDate('Wed, 26 Dec 2012 14:38:53')
     };
 
     var interval = CronExpression.parse('15 10 * jAn-FeB mOn-tUE', options);
@@ -430,8 +430,8 @@ test('expression using mixed days of week strings', function(t) {
 test('expression using non-standard second field (wildcard)', function(t) {
   try {
     var options = {
-      currentDate: new CronDate('2012-12-26 14:38:00'),
-      endDate: new CronDate('2012-12-26 15:40:00')
+      currentDate: new CronDate('Wed, 26 Dec 2012 14:38:00'),
+      endDate: new CronDate('Wed, 26 Dec 2012 15:40:00')
     };
 
     var interval = CronExpression.parse('* * * * * *', options);
@@ -456,8 +456,8 @@ test('expression using non-standard second field (wildcard)', function(t) {
 test('expression using non-standard second field (step)', function(t) {
   try {
     var options = {
-      currentDate: new CronDate('2012-12-26 14:38:00'),
-      endDate: new CronDate('2012-12-26 15:40:00')
+      currentDate: new CronDate('Wed, 26 Dec 2012 14:38:00'),
+      endDate: new CronDate('Wed, 26 Dec 2012 15:40:00')
     };
 
     var interval = CronExpression.parse('*/20 * * * * *', options);
@@ -479,8 +479,8 @@ test('expression using non-standard second field (step)', function(t) {
 test('expression using non-standard second field (range)', function(t) {
   try {
     var options = {
-      currentDate: new CronDate('2012-12-26 14:38:53'),
-      endDate: new CronDate('2012-12-26 15:40:00')
+      currentDate: new CronDate('Wed, 26 Dec 2012 14:38:00'),
+      endDate: new CronDate('Wed, 26 Dec 2012 15:40:00')
     };
 
     var interval = CronExpression.parse('20-40/10 * * * * *', options);
@@ -732,8 +732,8 @@ test('day of month value can\'t be larger than days in month maximum value if it
 test('valid ES6 iterator should be returned if iterator options is set to true', function(t) {
   try {
     var options = {
-      currentDate: new CronDate('2012-12-26 14:38:53'),
-      endDate: new CronDate('2012-12-26 15:40:00'),
+      currentDate: new CronDate('Wed, 26 Dec 2012 14:38:53'),
+      endDate: new CronDate('Wed, 26 Dec 2012 15:40:00'),
       iterator: true
     };
 

--- a/test/expression.js
+++ b/test/expression.js
@@ -294,8 +294,8 @@ test('predefined expression', function(t) {
 test('expression limited with start and end date', function(t) {
   try {
     var options = {
-      currentDate: new CronDate('Wed, 26 Dec 2012 14:38:53'),
-      endDate: new CronDate('Wed, 26 Dec 2012 16:40:00')
+      currentDate: new CronDate('2012-12-26 14:38:53'),
+      endDate: new CronDate('2012-12-26 16:40:00')
     };
 
     var interval = CronExpression.parse('*/20 * * * *', options);
@@ -400,7 +400,7 @@ test('expression using days of week strings', function(t) {
 test('expression using mixed days of week strings', function(t) {
   try {
     var options = {
-      currentDate: new CronDate('Wed, 26 Dec 2012 14:38:53')
+      currentDate: new CronDate('2012-12-26 14:38:53')
     };
 
     var interval = CronExpression.parse('15 10 * jAn-FeB mOn-tUE', options);
@@ -430,8 +430,8 @@ test('expression using mixed days of week strings', function(t) {
 test('expression using non-standard second field (wildcard)', function(t) {
   try {
     var options = {
-      currentDate: new CronDate('Wed, 26 Dec 2012 14:38:00'),
-      endDate: new CronDate('Wed, 26 Dec 2012 15:40:00')
+      currentDate: new CronDate('2012-12-26 14:38:00'),
+      endDate: new CronDate('2012-12-26 15:40:00')
     };
 
     var interval = CronExpression.parse('* * * * * *', options);
@@ -456,8 +456,8 @@ test('expression using non-standard second field (wildcard)', function(t) {
 test('expression using non-standard second field (step)', function(t) {
   try {
     var options = {
-      currentDate: new CronDate('Wed, 26 Dec 2012 14:38:00'),
-      endDate: new CronDate('Wed, 26 Dec 2012 15:40:00')
+      currentDate: new CronDate('2012-12-26 14:38:00'),
+      endDate: new CronDate('2012-12-26 15:40:00')
     };
 
     var interval = CronExpression.parse('*/20 * * * * *', options);
@@ -479,8 +479,8 @@ test('expression using non-standard second field (step)', function(t) {
 test('expression using non-standard second field (range)', function(t) {
   try {
     var options = {
-      currentDate: new CronDate('Wed, 26 Dec 2012 14:38:00'),
-      endDate: new CronDate('Wed, 26 Dec 2012 15:40:00')
+      currentDate: new CronDate('2012-12-26 14:38:53'),
+      endDate: new CronDate('2012-12-26 15:40:00')
     };
 
     var interval = CronExpression.parse('20-40/10 * * * * *', options);
@@ -732,8 +732,8 @@ test('day of month value can\'t be larger than days in month maximum value if it
 test('valid ES6 iterator should be returned if iterator options is set to true', function(t) {
   try {
     var options = {
-      currentDate: new CronDate('Wed, 26 Dec 2012 14:38:53'),
-      endDate: new CronDate('Wed, 26 Dec 2012 15:40:00'),
+      currentDate: new CronDate('2012-12-26 14:38:53'),
+      endDate: new CronDate('2012-12-26 15:40:00'),
       iterator: true
     };
 

--- a/test/timezone.js
+++ b/test/timezone.js
@@ -17,7 +17,7 @@ test('It works on DST start', function(t) {
     t.equal(date.getMinutes(), 0, '0 Minutes');
     t.equal(date.getHours(), 4, 'Due to DST start in Athens, 3 is skipped');
     t.equal(date.getDate(), 27, 'on the 27th');
-  
+
     date = interval.next();
     t.equal(date.getMinutes(), 0, '0 Minutes');
     t.equal(date.getHours(), 5, '5 AM');
@@ -57,9 +57,58 @@ test('It works on DST start', function(t) {
     date = interval.next();
     t.equal(date.getMinutes(), 0, '0 Minutes');
     t.equal(date.getHours(), 3, '3 AM');
-    t.equal(date.getDate(), 28, 'on the 27th');
-    
+    t.equal(date.getDate(), 28, 'on the 28th');
 
+    options.currentDate = '2016-03-27 00:00:01';
+
+    interval = CronExpression.parse('0 * 27 * *', options);
+    t.ok(interval, 'Interval parsed');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0 Minutes');
+    t.equal(date.getHours(), 1, '1 AM');
+    t.equal(date.getDate(), 27, 'on the 27th');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0 Minutes');
+    t.equal(date.getHours(), 2, '2 AM');
+    t.equal(date.getDate(), 27, 'on the 27th');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0 Minutes');
+    t.equal(date.getHours(), 4, '4 AM');
+    t.equal(date.getDate(), 27, 'on the 27th');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0 Minutes');
+    t.equal(date.getHours(), 5, '5 AM');
+    t.equal(date.getDate(), 27, 'on the 27th');
+
+    options.currentDate = '2016-03-27 00:00:01';
+    options.endDate = '2016-03-27 03:00:01';
+
+    interval = CronExpression.parse('0 * * * *', options);
+    t.ok(interval, 'Interval parsed');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0 Minutes');
+    t.equal(date.getHours(), 1, '1 AM');
+    t.equal(date.getDate(), 27, 'on the 27th');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0 Minutes');
+    t.equal(date.getHours(), 2, '2 AM');
+    t.equal(date.getDate(), 27, 'on the 27th');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0 Minutes');
+    t.equal(date.getHours(), 4, '4 AM');
+    t.equal(date.getDate(), 27, 'on the 27th');
+
+    // Out of the timespan range
+    t.throws(function() {
+        date = interval.next();
+    });
   } catch (err) {
     t.ifError(err, 'Interval parse error');
   }
@@ -124,7 +173,84 @@ test('It works on DST end', function(t) {
     t.equal(date.getMinutes(), 0, '0');
     t.equal(date.getHours(), 3, '3 AM');
     t.equal(date.getDate(), 31, '31st');
-    
+
+    options.currentDate = '2016-10-30 00:00:01';
+
+    interval = CronExpression.parse('0 * 30 * *', options);
+    t.ok(interval, 'Interval parsed');
+
+    date = interval.next();
+    t.equal(date.getHours(), 1, '1 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    date = interval.next();
+    t.equal(date.getHours(), 2, '2 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    date = interval.next();
+    t.equal(date.getHours(), 3, '3 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    date = interval.next();
+    t.equal(date.getHours(), 3, '3 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    date = interval.next();
+    t.equal(date.getHours(), 4, '4 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    options.currentDate = '2016-10-30 00:00:01';
+    options.endDate = '2016-10-30 03:00:01';
+
+    interval = CronExpression.parse('0 * * * *', options);
+    t.ok(interval, 'Interval parsed');
+
+    date = interval.next();
+    t.equal(date.getHours(), 1, '1 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    date = interval.next();
+    t.equal(date.getHours(), 2, '2 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    date = interval.next();
+    t.equal(date.getHours(), 3, '3 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    // Out of the timespan range
+    t.throws(function() {
+        date = interval.next();
+    });
+
+    options.endDate = '2016-10-30 04:00:01';
+
+    interval = CronExpression.parse('0 * * * *', options);
+    t.ok(interval, 'Interval parsed');
+
+    date = interval.next();
+    t.equal(date.getHours(), 1, '1 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    date = interval.next();
+    t.equal(date.getHours(), 2, '2 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    date = interval.next();
+    t.equal(date.getHours(), 3, '3 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    date = interval.next();
+    t.equal(date.getHours(), 3, '3 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    date = interval.next();
+    t.equal(date.getHours(), 4, '4 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    // Out of the timespan range
+    t.throws(function() {
+        date = interval.next();
+    });
    } catch (err) {
     t.ifError(err, 'Interval parse error');
   }

--- a/test/timezone.js
+++ b/test/timezone.js
@@ -8,11 +8,58 @@ test('It works on DST start', function(t) {
       tz: 'Europe/Athens'
     };
 
-    var interval = CronExpression.parse('0 * * * *', options);
+    var interval, date;
+
+    interval = CronExpression.parse('0 * * * *', options);
     t.ok(interval, 'Interval parsed');
 
-    var date = interval.next();
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0 Minutes');
     t.equal(date.getHours(), 4, 'Due to DST start in Athens, 3 is skipped');
+    t.equal(date.getDate(), 27, 'on the 27th');
+  
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0 Minutes');
+    t.equal(date.getHours(), 5, '5 AM');
+    t.equal(date.getDate(), 27, 'on the 27th');
+
+    interval = CronExpression.parse('0 3 * * *', options);
+    t.ok(interval, 'Interval parsed');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0 Minutes');
+    t.equal(date.getHours(), 4, 'Due to DST start in Athens, 3 is skipped');
+    t.equal(date.getDate(), 27, 'on the 27th');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0 Minutes');
+    t.equal(date.getHours(), 3, '3 on the 28th');
+    t.equal(date.getDate(), 28, 'on the 28th');
+
+    interval = CronExpression.parse('*/20 3 * * *', options);
+    t.ok(interval, 'Interval parsed');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0 Minutes');
+    t.equal(date.getHours(), 4, 'Due to DST start in Athens, 3 is skipped');
+    t.equal(date.getDate(), 27, 'on the 27th');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 20, '20 Minutes');
+    t.equal(date.getHours(), 4, 'Due to DST start in Athens, 3 is skipped');
+    t.equal(date.getDate(), 27, 'on the 27th');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 40, '20 Minutes');
+    t.equal(date.getHours(), 4, 'Due to DST start in Athens, 3 is skipped');
+    t.equal(date.getDate(), 27, 'on the 27th');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0 Minutes');
+    t.equal(date.getHours(), 3, '3 AM');
+    t.equal(date.getDate(), 28, 'on the 27th');
+    
+
   } catch (err) {
     t.ifError(err, 'Interval parse error');
   }
@@ -27,16 +74,58 @@ test('It works on DST end', function(t) {
       tz: 'Europe/Athens'
     };
 
-    var interval = CronExpression.parse('0 * * * *', options);
+    var interval, date;
+
+    interval = CronExpression.parse('0 * * * *', options);
     t.ok(interval, 'Interval parsed');
 
-    var date = interval.next();
+    date = interval.next();
     t.equal(date.getHours(), 3, '3 AM');
+    t.equal(date.getDate(), 30, '30th');
+
     date = interval.next();
     t.equal(date.getHours(), 3, 'Due to DST end in Athens (4-->3)');
+    t.equal(date.getDate(), 30, '30th');
+
     date = interval.next();
     t.equal(date.getHours(), 4, '4 AM');
-  } catch (err) {
+    t.equal(date.getDate(), 30, '30th');
+
+    interval = CronExpression.parse('0 3 * * *', options);
+    t.ok(interval, 'Interval parsed');
+
+    date = interval.next();
+    t.equal(date.getHours(), 3, '3 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    date = interval.next();
+    t.equal(date.getHours(), 3, '3 AM');
+    t.equal(date.getDate(), 31, '31st');
+
+    interval = CronExpression.parse('*/20 3 * * *', options);
+    t.ok(interval, 'Interval parsed');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0');
+    t.equal(date.getHours(), 3, '3 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 20, '20');
+    t.equal(date.getHours(), 3, '3 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 40, '40');
+    t.equal(date.getHours(), 3, '3 AM');
+    t.equal(date.getDate(), 30, '30th');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 0, '0');
+    t.equal(date.getHours(), 3, '3 AM');
+    t.equal(date.getDate(), 31, '31st');
+    
+   } catch (err) {
     t.ifError(err, 'Interval parse error');
   }
 

--- a/test/timezone.js
+++ b/test/timezone.js
@@ -1,0 +1,44 @@
+var test = require('tap').test;
+var CronExpression = require('../lib/expression');
+
+test('It works on DST start', function(t) {
+  try {
+    var options = {
+      currentDate: '2016-03-27 02:00:01',
+      tz: 'Europe/Athens'
+    };
+
+    var interval = CronExpression.parse('0 * * * *', options);
+    t.ok(interval, 'Interval parsed');
+
+    var date = interval.next();
+    t.equal(date.getHours(), 4, 'Due to DST start in Athens, 3 is skipped');
+  } catch (err) {
+    t.ifError(err, 'Interval parse error');
+  }
+
+  t.end();
+});
+
+test('It works on DST end', function(t) {
+  try {
+    var options = {
+      currentDate: '2016-10-30 02:00:01',
+      tz: 'Europe/Athens'
+    };
+
+    var interval = CronExpression.parse('0 * * * *', options);
+    t.ok(interval, 'Interval parsed');
+
+    var date = interval.next();
+    t.equal(date.getHours(), 3, '3 AM');
+    date = interval.next();
+    t.equal(date.getHours(), 3, 'Due to DST end in Athens (4-->3)');
+    date = interval.next();
+    t.equal(date.getHours(), 4, '4 AM');
+  } catch (err) {
+    t.ifError(err, 'Interval parse error');
+  }
+
+  t.end();
+});


### PR DESCRIPTION
Hi!
I'm a maintainer of [node-schedule](https://github.com/node-schedule/node-schedule) and we rely on your `CronDate` implementation for our *calculations*. It's been great so far. Thanks a lot!
It's been on our roadmap for some time adding timezone support to our module: https://github.com/node-schedule/node-schedule/issues/217 and the simpler way for us would be adding timezone support to `CronDate`.
This PR adds that support by using `moment-timezone` while trying to keep your module working. The tests are passing and the only modification I had to do was with the `31_of_month.js` because after 20 operations the date reached year 2019 which is the last year that supports by default `moment-timezone`. Adding timezone support to `cron-parser` next should be trivial.

Is this something you would be interested in?

Thanks in advance!