### PR TITLE
Resolve issue with IE and isNaN

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -3,6 +3,9 @@
 // Load Date class extensions
 require('./date');
 
+// Load fix for isNaN (IE)
+require('./number');
+
 /**
  * Construct a new expression parser
  *

--- a/lib/number.js
+++ b/lib/number.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Polyfill. IE Number.isNaN does not support method 'isNaN'.
+ */
+Number.isNaN = Number.isNaN || function(value) {
+    return typeof value === 'number' && isNaN(value);
+}


### PR DESCRIPTION
There is a fix for using Number.isNaN with IE browser.
See attached image.
![screen shot 2016-03-09 at 12 29 41](https://cloud.githubusercontent.com/assets/3840623/13632601/228c0004-e5f3-11e5-93ca-1be8115b016a.png)
