### PR TITLE
Target more appropriate node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js: 
   - "0.12"
-  - "0.11"
   - "0.10"
-  - "iojs"
+  - 4
+  - 5


### PR DESCRIPTION
Suggest we drop io.js and 0.11 (not supported anymore). Swap these out for 4 and 5.