### PR TITLE
Use is-nan to get Number.isNaN

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -3,8 +3,8 @@
 // Load Date class extensions
 var CronDate = require('./date');
 
-// Load fix for isNaN (IE)
-require('./number');
+// Get Number.isNaN or the polyfill
+var safeIsNaN = require('is-nan');
 
 /**
  * Construct a new expression parser
@@ -271,7 +271,7 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
       var min = +atoms[0];
       var max = +atoms[1];
 
-      if (Number.isNaN(min) || Number.isNaN(max) ||
+      if (safeIsNaN(min) || safeIsNaN(max) ||
           min < constraints[0] || max > constraints[1]) {
         throw new Error(
           'Constraint error, got range ' +
@@ -286,7 +286,7 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
       // Create range
       var repeatIndex = +repeatInterval;
 
-      if (Number.isNaN(repeatIndex) || repeatIndex <= 0) {
+      if (safeIsNaN(repeatIndex) || repeatIndex <= 0) {
         throw new Error('Constraint error, cannot repeat at every ' + repeatIndex + ' time.');
       }
 

--- a/lib/number.js
+++ b/lib/number.js
@@ -1,8 +1,0 @@
-'use strict';
-
-/**
- * Polyfill. IE Number.isNaN does not support method 'isNaN'.
- */
-Number.isNaN = Number.isNaN || function(value) {
-    return typeof value === 'number' && isNaN(value);
-}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "is-nan": "^1.2.1",
     "moment-timezone": "^0.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This replaces the `Number.isNaN` polyfill with [is-nan](https://github.com/ljharb/is-nan). `Number.isNaN` shouldn't be an enumerable property, so polyfilling it that way means you end up with a dirty environment.