### PR TITLE
travis: swap unsupported node versions for stable ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js: 
+  - "4"
+  - "5"
   - "0.12"
-  - "0.11"
   - "0.10"
-  - "iojs"


### PR DESCRIPTION
This drops iojs and 0.11, both of which are not supported anymore.

Also adds 4 and 5