### PR TITLE
Fix matching intervals being skipped when both dayOfWeek and dayOfMonth are restricted

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -440,7 +440,7 @@ CronExpression.prototype._findSchedule = function _findSchedule () {
     }
 
     // Add day if select day not match with month (according to calendar)
-    if (!dayOfMonthMatch || !dayOfWeekMatch) {
+    if (!dayOfMonthMatch && !dayOfWeekMatch) {
       currentDate.addDay();
       continue;
     }

--- a/test/expression.js
+++ b/test/expression.js
@@ -144,9 +144,8 @@ test('fixed expression test', function(t) {
     var next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 0, 'Day matches');
+    t.ok(next.getDay() === 0 || next.getDate() === 12, 'Day or day of Month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
     t.equal(next.getHours(), 2, 'Hour matches');
     t.equal(next.getMinutes(), 10, 'Minute matches');
   } catch (err) {
@@ -234,9 +233,8 @@ test('range test with iterator', function(t) {
       var next = intervals[i];
 
       t.ok(next, 'Found next scheduled interval');
-      t.equal(next.getDay(), 0, 'Day matches');
+      t.ok(next.getDay() === 0 || next.getDate() === 12, 'Day or day of month matches');
       t.equal(next.getMonth(), 7, 'Month matches');
-      t.equal(next.getDate(), 12, 'Day of month matches');
       t.equal(next.getHours(), 2, 'Hour matches');
       t.equal(next.getMinutes(), 10 + i, 'Minute matches');
     }
@@ -259,9 +257,8 @@ test('incremental range test with iterator', function(t) {
       var next = intervals[i];
 
       t.ok(next, 'Found next scheduled interval');
-      t.equal(next.getDay(), 0, 'Day matches');
+      t.ok(next.getDay() === 0 || next.getDate() === 12, 'Day or day of month matches');
       t.equal(next.getMonth(), 7, 'Month matches');
-      t.equal(next.getDate(), 12, 'Day of month matches');
       t.equal(next.getHours(), 2, 'Hour matches');
       t.equal(next.getMinutes(), 10 + (i * 2), 'Minute matches');
     }
@@ -510,30 +507,26 @@ test('day of month and week are both set', function(t) {
     var next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 0, 'Day matches');
+    t.ok(next.getDay() === 0 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 0, 'Day matches');
+    t.ok(next.getDay() === 0 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 0, 'Day matches');
+    t.ok(next.getDay() === 0 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 0, 'Day matches');
+    t.ok(next.getDay() === 0 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
   } catch (err) {
     t.ifError(err, 'Interval parse error');
   }
@@ -567,30 +560,26 @@ test('day of month and week are both set and dow is 7', function(t) {
     var next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 0, 'Day matches');
+    t.ok(next.getDay() === 0 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 0, 'Day matches');
+    t.ok(next.getDay() === 0 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 0, 'Day matches');
+    t.ok(next.getDay() === 0 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 0, 'Day matches');
+    t.ok(next.getDay() === 0 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
   } catch (err) {
     t.ifError(err, 'Interval parse error');
   }
@@ -606,30 +595,26 @@ test('day of month and week are both set and dow is 6,0', function(t) {
     var next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 6, 'Day matches');
+    t.ok(next.getDay() === 6 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 6, 'Day matches');
+    t.ok(next.getDay() === 6 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 6, 'Day matches');
+    t.ok(next.getDay() === 6 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
 
     // next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 6, 'Day matches');
+    t.ok(next.getDay() === 6 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
   } catch (err) {
     t.ifError(err, 'Interval parse error');
   }
@@ -646,30 +631,26 @@ test('day of month and week are both set and dow is 6-7', function(t) {
     var next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 6, 'Day matches');
+    t.ok(next.getDay() === 6 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 6, 'Day matches');
+    t.ok(next.getDay() === 6 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 6, 'Day matches');
+    t.ok(next.getDay() === 6 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
 
     // next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
-    t.equal(next.getDay(), 6, 'Day matches');
+    t.ok(next.getDay() === 6 || next.getDate() === 12, 'Day or day of month matches');
     t.equal(next.getMonth(), 7, 'Month matches');
-    t.equal(next.getDate(), 12, 'Day of month matches');
   } catch (err) {
     t.ifError(err, 'Interval parse error');
   }
@@ -686,22 +667,19 @@ test('day and date in week should matches', function(t){
 
     t.ok(next, 'Found next scheduled interval');
     t.equal(next.getHours(), 1, 'Hours matches');
-    t.equal(next.getDay(), 1, 'Day matches');
-    t.equal(next.getDate(), 1, 'Day of month matches');
+    t.ok(next.getDay() === 1 || next.getDate() === 1, 'Day or day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
     t.equal(next.getHours(), 1, 'Hours matches');
-    t.equal(next.getDay(), 1, 'Day matches');
-    t.equal(next.getDate(), 1, 'Day of month matches');
+    t.ok(next.getDay() === 1 || next.getDate() === 1, 'Day or day of month matches');
 
     next = interval.next();
 
     t.ok(next, 'Found next scheduled interval');
     t.equal(next.getHours(), 1, 'Hours matches');
-    t.equal(next.getDay(), 1, 'Day matches');
-    t.equal(next.getDate(), 1, 'Day of month matches');
+    t.ok(next.getDay() === 1 || next.getDate() === 1, 'Day or day of month matches');
 
   } catch (err) {
     t.ifError(err, 'Interval parse error');


### PR DESCRIPTION
Based on this commented quote, if **both** dayOfWeek and dayOfMonth are restricted, then when at least one of them matches the current date, the command should be run.

>     // "The day of a command's execution can be specified by two fields --
    // day of month, and day of week.  If  both	 fields	 are  restricted  (ie,
    // aren't  *),  the command will be run when either field matches the cur-
    // rent time.  For example, "30 4 1,15 * 5" would cause a command to be
    // run at 4:30 am on the  1st and 15th of each month, plus every Friday."

The previous behavior was that the command would run if and only if both matched, which does not match the quoted behavior.

You can verify this with the following code:

```javascript
var cronParser = require('cron-parser');
var date = cronParser.parseExpression('0 0 10 1 * 5', {currentDate: '2016-05-25T00:00:00.000Z'});
console.log(date.next().toISOString());
// got 2016-07-01T14:00:00.000Z (Friday, July 1st, 2016)
// expected 2016-05-27T14:00:00.000Z (Friday, May 27th, 2016)

console.log(date.next().toISOString());
// got 2017-09-01T14:00:00.000Z
// expected 2016-06-01T14:00:00.000Z (doesn't match Friday, but matches 1st of month)

console.log(date.next().toISOString());
// got 2017-12-01T15:00:00.000Z
// expected 2016-06-03T14:00:00.000Z (doesn't match 1st of month, but matches Friday)
```