### PR TITLE
src: fix case on DST start transition

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -328,7 +328,7 @@ CronExpression.prototype._applyTimezoneShift = function(currentDate, method) {
       this._dstEnd = currentHour;
     }
   }
-}
+};
 
 
 /**
@@ -475,6 +475,9 @@ CronExpression.prototype._findSchedule = function _findSchedule () {
       if (this._dstStart !== currentHour) {
         this._dstStart = null;
         this._applyTimezoneShift(currentDate, 'addHour');
+        continue;
+      } else if (!matchSchedule(currentHour - 1, this._fields.hour)) {
+        currentDate.addHour();
         continue;
       }
     } else if (this._dstEnd === currentHour) {

--- a/test/timezone.js
+++ b/test/timezone.js
@@ -23,6 +23,19 @@ test('It works on DST start', function(t) {
     t.equal(date.getHours(), 5, '5 AM');
     t.equal(date.getDate(), 27, 'on the 27th');
 
+    interval = CronExpression.parse('30 2 * * *', options);
+    t.ok(interval, 'Interval parsed');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 30, '30 Minutes');
+    t.equal(date.getHours(), 2, '2 AM');
+    t.equal(date.getDate(), 27, 'on the 27th');
+
+    date = interval.next();
+    t.equal(date.getMinutes(), 30, '30 Minutes');
+    t.equal(date.getHours(), 2, '2 AM');
+    t.equal(date.getDate(), 28, 'on the 28th');
+
     interval = CronExpression.parse('0 3 * * *', options);
     t.ok(interval, 'Interval parsed');
 


### PR DESCRIPTION
On a DST start transition going from hour `H` to hour `H + 2`, having
a cron job expression like this: `m H * * *` was returning 2 valid dates @
`H:30:00` and `H+2:30:00`. This change fixes the issue so it only
returns `H:30:00`.

Fixes: https://github.com/harrisiirak/cron-parser/issues/66