### PR TITLE
Fix for each Nth value in a range

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -283,20 +283,16 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
         throw new Error('Invalid range: ' + val);
       }
 
-      // Create range
-      var repeatIndex = +repeatInterval;
-
-      if (safeIsNaN(repeatIndex) || repeatIndex <= 0) {
-        throw new Error('Constraint error, cannot repeat at every ' + repeatIndex + ' time.');
+      if (safeIsNaN(repeatInterval) || repeatInterval <= 0) {
+        throw new Error('Constraint error, cannot repeat at every ' + repeatInterval + ' time.');
       }
 
-      for (var index = min, count = max; index <= count; index++) {
-        if (repeatIndex > 0 && (repeatIndex % repeatInterval) === 0) {
-          repeatIndex = 1;
+      for (var index = min; index <= max; index++) {
+
+        if ( repeatInterval == 1 || index%repeatInterval == 0 ) {
           stack.push(index);
-        } else {
-          repeatIndex++;
         }
+
       }
 
       return stack;


### PR DESCRIPTION
The issue is described here https://github.com/node-schedule/node-schedule/issues/301. Commit looks as a fix. Unit tests were ok. And the result was as expected:
*/2 */3 */4 */2 */3 */2
[ 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58 ]
[ 0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48, 51, 54, 57 ]
[ 0, 4, 8, 12, 16, 20 ]
[ 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30 ]
[ 3, 6, 9, 12 ]
[ 0, 2, 4, 6 ]