### PR TITLE
Prevent recursive 'next' call in iterator mode

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -549,7 +549,7 @@ CronExpression.prototype.hasNext = function() {
   var current = this._currentDate;
 
   try {
-    this.next();
+    this._findSchedule();
     return true;
   } catch (err) {
     return false;


### PR DESCRIPTION
Closes #80.

There's probably an opportunity to be even faster by trying to cache the result of `_findSchedule` in `hasNext`, since it should be the next value to return anyways.