### PR TITLE
src: fix calculation when starting on full hours

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -394,13 +394,8 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
   var startDate = this._startDate;
   var endDate = this._endDate;
 
-  // TODO: Improve this part
-  // Always increment second value when second part is present
-  if (this._fields.second.length > 1 && !this._hasIterated) {
-    currentDate.addSecond();
-  }
-
   // Find matching schedule
+  var initial_ts = currentDate.getTime();
   while (true) {
     // Validate timespan
     if (reverse) {
@@ -517,16 +512,17 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
       continue;
     }
 
+    // Increase a second in case in the first iteration the currentDate was not
+    // modified
+    if (initial_ts === currentDate.getTime()) {
+      this._applyTimezoneShift(currentDate, dateMathVerb + 'Second');
+      continue;
+    }
+
     break;
   }
 
-  // When internal date is not mutated, append one second as a padding
-  var nextDate = new CronDate(currentDate, this._tz);
-  if (this._currentDate !== currentDate) {
-    nextDate[dateMathVerb + 'Second']();
-  }
-
-  this._currentDate = nextDate;
+  this._currentDate = new CronDate(currentDate, this._tz);
   this._hasIterated = true;
 
   return currentDate;

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "moment-timezone": "^0.5.0"
   },
   "devDependencies": {
+    "sinon": "^1.17.7",
     "tap": "^0.5.0"
   },
   "engines": {

--- a/test/increment_on_first_iteration.js
+++ b/test/increment_on_first_iteration.js
@@ -1,0 +1,22 @@
+var util = require('util');
+var sinon = require('sinon');
+var test = require('tap').test;
+var CronExpression = require('../lib/expression');
+
+test('increment_on_first_itereation', function(t) {
+  try {
+    var clock = sinon.useFakeTimers();
+    var fake_now = new Date('Tue Feb 21 2017 16:45:00');
+    clock.tick(fake_now.getTime());
+    var interval = CronExpression.parse('* * * * *');
+    t.ok(interval, 'Interval parsed');
+    var next = interval.next();
+    t.ok(next, 'Found next scheduled interval');
+    // Make sure next has incremented in 1 minute
+    t.equal(fake_now.getTime() + 60000, next.getTime());
+    clock.restore();
+    t.end();
+  } catch (err) {
+    t.ifError(err, 'Interval parse error');
+  }
+});


### PR DESCRIPTION
On this scenario, the first returned date by `next()` would be the same
as the current date.

Fixes: https://github.com/harrisiirak/cron-parser/issues/91