### PR TITLE
src: fix UTC handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,4 +126,4 @@ will be expecting. Using one of the supported `string` formats will solve the is
 
 * *iterator* - Return ES6 compatible iterator object 
 * *utc* - Enable UTC
-* *tz* - Timezone string
+* *tz* - Timezone string. It won't be used in case `utc` is enabled

--- a/lib/expression.js
+++ b/lib/expression.js
@@ -20,14 +20,14 @@ var safeIsNaN = require('is-nan');
  */
 function CronExpression (fields, options) {
   this._options = options;
-  this._tz = options.tz;
+  this._utc = options.utc || false;
+  this._tz = this._utc ? 'UTC' : options.tz;
   this._currentDate = new CronDate(options.currentDate, this._tz);
   this._startDate = options.startDate ? new CronDate(options.startDate, this._tz) : null;
   this._endDate = options.endDate ? new CronDate(options.endDate, this._tz) : null;
   this._fields = {};
   this._isIterator = options.iterator || false;
   this._hasIterated = false;
-  this._utc = options.utc || false;
 
   // Map fields
   for (var i = 0, c = CronExpression.map.length; i < c; i++) {
@@ -384,10 +384,6 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
   reverse = reverse || false;
   var dateMathVerb = reverse ? 'subtract' : 'add';
 
-  var method = function(name) {
-    return !this._utc ? name : ('getUTC' + name.slice(3));
-  }.bind(this);
-
   var currentDate = new CronDate(this._currentDate, this._tz);
   var startDate = this._startDate;
   var endDate = this._endDate;
@@ -417,19 +413,19 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
     // http://unixhelp.ed.ac.uk/CGI/man-cgi?crontab+5
     //
 
-    var dayOfMonthMatch = matchSchedule(currentDate[method('getDate')](), this._fields.dayOfMonth);
-    var dayOfWeekMatch = matchSchedule(currentDate[method('getDay')](), this._fields.dayOfWeek);
+    var dayOfMonthMatch = matchSchedule(currentDate.getDate(), this._fields.dayOfMonth);
+    var dayOfWeekMatch = matchSchedule(currentDate.getDay(), this._fields.dayOfWeek);
 
     var isDayOfMonthWildcardMatch = isWildcardRange(this._fields.dayOfMonth, CronExpression.constraints[3]);
     var isMonthWildcardMatch = isWildcardRange(this._fields.month, CronExpression.constraints[4]);
     var isDayOfWeekWildcardMatch = isWildcardRange(this._fields.dayOfWeek, CronExpression.constraints[5]);
 
-    var currentHour = currentDate[method('getHours')]();
+    var currentHour = currentDate.getHours();
 
     // Validate days in month if explicit value is given
     if (!isMonthWildcardMatch) {
-      var currentYear = currentDate[method('getFullYear')]();
-      var currentMonth = currentDate[method('getMonth')]() + 1;
+      var currentYear = currentDate.getFullYear();
+      var currentMonth = currentDate.getMonth() + 1;
       var previousMonth = currentMonth === 1 ? 11 : currentMonth - 1;
       var daysInPreviousMonth = CronExpression.daysInMonth[previousMonth - 1];
       var daysOfMontRangeMax = this._fields.dayOfMonth[this._fields.dayOfMonth.length - 1];
@@ -475,7 +471,7 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
     }
 
     // Match month
-    if (!matchSchedule(currentDate[method('getMonth')]() + 1, this._fields.month)) {
+    if (!matchSchedule(currentDate.getMonth() + 1, this._fields.month)) {
       currentDate[dateMathVerb + 'Month']();
       continue;
     }
@@ -499,13 +495,13 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
     }
 
     // Match minute
-    if (!matchSchedule(currentDate[method('getMinutes')](), this._fields.minute)) {
+    if (!matchSchedule(currentDate.getMinutes(), this._fields.minute)) {
       this._applyTimezoneShift(currentDate, dateMathVerb + 'Minute');
       continue;
     }
 
     // Match second
-    if (!matchSchedule(currentDate[method('getSeconds')](), this._fields.second)) {
+    if (!matchSchedule(currentDate.getSeconds(), this._fields.second)) {
       this._applyTimezoneShift(currentDate, dateMathVerb + 'Second');
       continue;
     }

--- a/test/expression.js
+++ b/test/expression.js
@@ -463,13 +463,14 @@ test('parse expression as UTC', function(t) {
 
     var date = interval.next();
     t.equal(date.getUTCHours(), 10, 'Correct UTC hour value');
+    t.equal(date.getHours(), 10, 'Correct UTC hour value');
 
     interval = CronExpression.parse('0 */5 * * * *', options);
 
     var date = interval.next(), now = new Date();
     now.setMinutes(now.getMinutes() + 5 - (now.getMinutes() % 5));
 
-    t.equal(date.getHours(), now.getHours(), 'Correct local time for 5 minute interval');
+    t.equal(date.getHours(), now.getUTCHours(), 'Correct local time for 5 minute interval');
 
   } catch (err) {
     t.ifError(err, 'UTC parse error');


### PR DESCRIPTION
Use `moment.tz` `UTC` support directly and remove unneeded code.
Setting `utc` to `true` will always have preference over setting a
specific TZ.

Fixes: https://github.com/harrisiirak/cron-parser/issues/96