### PR TITLE
Fix the reporitory URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:harrisiirak/cron-parser.git"
+    "url": "https://github.com/harrisiirak/cron-parser.git"
   },
   "keywords": [
     "cron",


### PR DESCRIPTION
Use HTTPS as that's usable also without a GitHub account.