### PR TITLE
Added support for # character (with aliases H and h)

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -152,13 +152,18 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
   }
 
   // Check for valid characters.
-  if (!(/^[\d|/|*|\-|,]+$/.test(value))) {
+  if (!(/^[\d|/|*H#|\-|,]+$/i.test(value))) {
     throw new Error('Invalid characters, got value: ' + value)
   }
 
+  // If hash
+  var hash = /[H|#]/i.test(value)
+
   // Replace '*'
-  if (value.indexOf('*') !== -1) {
-    value = value.replace(/\*/g, constraints.join('-'));
+  if (value.includes('*') || hash && value.includes('/') ) {
+    value = value.replace(/\*|H|#/gi, constraints.join('-'));
+  } else if(hash && !value.includes('/') ) {
+    value = String(Math.floor(Math.random()*(constraints[1]-constraints[0]+1)+constraints[0]));
   }
 
   //
@@ -294,14 +299,36 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
         throw new Error('Constraint error, cannot repeat at every ' + repeatIndex + ' time.');
       }
 
+      // Calc random addition to spread load
+      if(hash) {
+          var hashAdd = Math.floor(Math.random()*(constraints[1]-constraints[0]+1)+constraints[0]);
+      }
+
       for (var index = min, count = max; index <= count; index++) {
         if (repeatIndex > 0 && (repeatIndex % repeatInterval) === 0) {
           repeatIndex = 1;
-          stack.push(index);
+
+          if(hash) {
+
+            var offsetIndex = index + hashAdd;
+
+            if(offsetIndex > constraints[1]) {
+               offsetIndex = offsetIndex - constraints[1] + constraints[0];
+            }
+
+            stack.push(offsetIndex);
+
+          } else {
+            stack.push(index);
+          }
+
         } else {
           repeatIndex++;
         }
       }
+
+      // Sort in acsending order.
+      stack.sort((a, b) => a - b);
 
       return stack;
     }


### PR DESCRIPTION
Simple fix i did for another project. Not the prettiest code but thought somebody might find it useful. Added support for `#` character (with aliases H and h), including `#/interval` to randomly select time of execution. Example `# * * * *` runs at a randomly selected minute each hour and `#/15 * * * *` runs every 15 minutes but not necessarily at 00.00, 00.15, 00.30, 00.45 and so on, like `*/15 * * * *` does.  Good for spreading the load on databases for example.