### PR TITLE
Fix infinite loop caused by specific invalid dates

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -440,7 +440,7 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
         _daysOfMontRangeMax = 29;
       }
 
-      if (previousMonth === 2 && this._fields.month[0] === previousMonth && _daysInPreviousMonth < _daysOfMontRangeMax) {
+      if (this._fields.month[0] === previousMonth && _daysInPreviousMonth < _daysOfMontRangeMax) {
         throw new Error('Invalid explicit day of month definition');
       }
     }

--- a/test/expression.js
+++ b/test/expression.js
@@ -799,7 +799,7 @@ test('day and date in week should matches', function(t){
 
 test('day of month value can\'t be larger than days in month maximum value if it\'s defined explicitly', function(t) {
   try {
-    var interval = CronExpression.parse('0 4 30 2 *');
+    var interval = CronExpression.parse('0 4 31 4 *');
     t.ok(interval, 'Interval parsed');
 
     try {
@@ -814,7 +814,6 @@ test('day of month value can\'t be larger than days in month maximum value if it
 
   t.end();
 });
-
 
 test('valid ES6 iterator should be returned if iterator options is set to true', function(t) {
   try {


### PR DESCRIPTION
Simplest repro that causes an infinite loop is:

```
const iter = require('cron-parser').parseExpression('* * * 31 4 *');
iter.next();
```

There was a safety check that look specifically at February. I made sure it applied to all months and changed the existing test to a different invalid date.