### PR TITLE
Typescript typings: Make "ParserOptions" properties optional

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -50,11 +50,12 @@ declare class CronDate {
 }
 
 interface ParserOptions {
-  currentDate: string | number | Date
-  endDate: string | number | Date
-  iterator: boolean
-  utc: boolean
-  tz: string
+  currentDate?: string | number | Date
+  startDate?: string | number | Date
+  endDate?: string | number | Date
+  iterator?: boolean
+  utc?: boolean
+  tz?: string
 }
 
 declare class CronExpression {


### PR DESCRIPTION
In the typings for the `ParserOptions` interface, all properties (`currentDate`, `endDate`, etc.) are marked as required.

However from reading the source code, it seems that all of these properties are actually optional and are filled with sensible defaults when not provided.

Also, I've added the `startDate` option, which was not specified in the typings.