### PR TITLE
add partial question mark support

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -123,6 +123,17 @@ CronExpression.aliases = {
  */
 CronExpression.parseDefaults = [ '0', '*', '*', '*', '*', '*' ];
 
+CronExpression.standardValidCharacters = /^[\d|/|*|\-|,]+$/;
+CronExpression.dayValidCharacters = /^[\d|/|*|\-|,|\?]+$/;
+CronExpression.validCharacters = {
+  second: CronExpression.standardValidCharacters,
+  minute: CronExpression.standardValidCharacters,
+  hour: CronExpression.standardValidCharacters,
+  dayOfMonth: CronExpression.dayValidCharacters,
+  month: CronExpression.standardValidCharacters,
+  dayOfWeek: CronExpression.dayValidCharacters,
+}
+
 /**
  * Parse input interval
  *
@@ -152,13 +163,15 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
   }
 
   // Check for valid characters.
-  if (!(/^[\d|/|*|\-|,]+$/.test(value))) {
+  if (!(CronExpression.validCharacters[field].test(value))) {
     throw new Error('Invalid characters, got value: ' + value)
   }
 
-  // Replace '*'
+  // Replace '*' and '?'
   if (value.indexOf('*') !== -1) {
     value = value.replace(/\*/g, constraints.join('-'));
+  } else if (value.indexOf('?') !== -1) {
+    value = value.replace(/\?/g, constraints.join('-'));
   }
 
   //

--- a/test/expression.js
+++ b/test/expression.js
@@ -643,6 +643,69 @@ test('day of month and week are both set', function(t) {
   t.end();
 });
 
+test('day of month is unspecified', function(t) {
+  try {
+    var interval = CronExpression.parse('10 2 ? * 3');
+
+    t.ok(interval, 'Interval parsed');
+    
+    var next = interval.next();
+    t.ok(next, 'Found next scheduled interal');
+    t.ok(next.getDay() === 3, 'day of week matches');
+
+    next = interval.next();
+    t.ok(next, 'Found next scheduled interal');
+    t.ok(next.getDay() === 3, 'day of week matches');
+
+    next = interval.next();
+    t.ok(next, 'Found next scheduled interal');
+    t.ok(next.getDay() === 3, 'day of week matches');
+
+    next = interval.next();
+    t.ok(next, 'Found next scheduled interal');
+    t.ok(next.getDay() === 3, 'day of week matches');
+
+  } catch (err) {
+    t.ifError(err, 'Interval parse error');
+  }
+
+  t.end();
+});
+
+test('day of week is unspecified', function(t) {
+  try {
+    var interval = CronExpression.parse('10 2 3,6 * ?');
+
+    t.ok(interval, 'Interval parsed');
+
+    var next = interval.next();
+    t.ok(next, 'Found next scheduled interal');
+    t.ok(next.getDate() === 3 || next.getDate() === 6, 'date matches');
+    var prevDate = next.getDate();
+
+    next = interval.next();
+    t.ok(next, 'Found next scheduled interal');
+    t.ok((next.getDate() === 3 || next.getDate() === 6) &&
+      next.getDate() !== prevDate, 'date matches and is not previous date');
+    prevDate = next.getDate();
+
+    next = interval.next();
+    t.ok(next, 'Found next scheduled interal');
+    t.ok((next.getDate() === 3 || next.getDate() === 6) &&
+      next.getDate() !== prevDate, 'date matches and is not previous date');
+    prevDate = next.getDate();
+
+    next = interval.next();
+    t.ok(next, 'Found next scheduled interal');
+    t.ok((next.getDate() === 3 || next.getDate() === 6) &&
+      next.getDate() !== prevDate, 'date matches and is not previous date');
+  } catch (err) {
+    t.ifError(err, 'Interval parse error');
+  }
+
+  t.end();
+});
+
 test('Summertime bug test', function(t) {
   try {
     var month = new CronDate().getMonth() + 1;


### PR DESCRIPTION
This patch adds support for '?' in the dayOfWeek / dayofMonth fields. It is really only partial support, because these are not so much wildcards ('*'), but "undefined" specifiers that indicate that only one of the two fields is being specified. 

To support the '?' specifier correctly, I'd need to remove the support for both being specified - technically only one is supposed to be specified, not both (at least according to various sources I can find; see below). I don't think that removing that support is such a great idea given it would break things for other users. From what I can see, it basically behaves like a wildcard anyway, and this is how I have implemented it.

https://www.baeldung.com/cron-expressions
http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html