### PR TITLE
test: Delete redundant path

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "./node_modules/.bin/tap ./test/*.js"
+    "test": "tap ./test/*.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`./node_modules/.bin` should be in the `PATH` when executing `npm` scripts using `npm run`