### PR TITLE
feat: support 'L' of dayOfMonth

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -194,6 +194,10 @@ CronDate.prototype.toDate = function() {
   return this._date.toDate();
 };
 
+CronDate.prototype.format = function(format = 'YYYY-MM-DD') {
+  return this._date.format(format);
+};
+
 function CronDate (timestamp, tz) {
   if (timestamp instanceof CronDate) {
     timestamp = timestamp._date;

--- a/lib/date.js
+++ b/lib/date.js
@@ -194,8 +194,8 @@ CronDate.prototype.toDate = function() {
   return this._date.toDate();
 };
 
-CronDate.prototype.format = function(format = 'YYYY-MM-DD') {
-  return this._date.format(format);
+CronDate.prototype.format = function(format) {
+  return this._date.format(format || 'YYYY-MM-DD');
 };
 
 function CronDate (timestamp, tz) {

--- a/lib/expression.js
+++ b/lib/expression.js
@@ -3,6 +3,8 @@
 // Load Date class extensions
 var CronDate = require('./date');
 
+var moment = require('moment-timezone');
+
 // Get Number.isNaN or the polyfill
 var safeIsNaN = require('is-nan');
 
@@ -124,7 +126,7 @@ CronExpression.aliases = {
 CronExpression.parseDefaults = [ '0', '*', '*', '*', '*', '*' ];
 
 CronExpression.standardValidCharacters = /^[\d|/|*|\-|,]+$/;
-CronExpression.dayValidCharacters = /^[\d|/|*|\-|,|\?]+$/;
+CronExpression.dayValidCharacters = /^[L|\d|/|*|\-|,|\?]+$/;
 CronExpression.validCharacters = {
   second: CronExpression.standardValidCharacters,
   minute: CronExpression.standardValidCharacters,
@@ -191,6 +193,10 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
    */
   function parseSequence (val) {
     var stack = [];
+    if (val === 'L') {
+      stack.push(val);
+      return stack;
+    }
 
     function handleResult (result) {
       var max = stack.length > 0 ? Math.max.apply(Math, stack) : -1;
@@ -360,10 +366,15 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
    *
    * @param {String} value
    * @param {Array} sequence
+   * @param {String} type
+   * @param {CronDate} date
    * @return {Boolean}
    * @private
    */
-  function matchSchedule (value, sequence) {
+  function matchSchedule (value, sequence, type, date) {
+    if (type === 'dayOfMonth' && sequence[0] === 'L') {
+      return moment(date.format()).endOf('month').date() === value;
+    }
     for (var i = 0, c = sequence.length; i < c; i++) {
       if (sequence[i] >= value) {
         return sequence[i] === value;
@@ -425,7 +436,7 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
     // http://unixhelp.ed.ac.uk/CGI/man-cgi?crontab+5
     //
 
-    var dayOfMonthMatch = matchSchedule(currentDate.getDate(), this._fields.dayOfMonth);
+    var dayOfMonthMatch = matchSchedule(currentDate.getDate(), this._fields.dayOfMonth, 'dayOfMonth', currentDate);
     var dayOfWeekMatch = matchSchedule(currentDate.getDay(), this._fields.dayOfWeek);
 
     var isDayOfMonthWildcardMatch = isWildcardRange(this._fields.dayOfMonth, CronExpression.constraints[3]);

--- a/test/last_day_of_month.js
+++ b/test/last_day_of_month.js
@@ -1,0 +1,16 @@
+var test = require('tap').test;
+var expression = require('../lib/expression');
+
+test('expression last day of month', function(t) {
+  try {
+    var interval = expression.parse('0 0 1 L * *');
+    var i;
+    var d;
+    for (i = 0; i < 20; ++i) {
+      d = interval.next();
+    }
+    t.end();
+  } catch (err) {
+    t.ifError(err, 'Interval parse error');
+  }
+});


### PR DESCRIPTION
Actually only partial support, only support the last day, not support the last days.
For example:
``` js
const interval = parser.parseExpression('0 0 1 L * *'); // The time is now 'Mon Oct 08 2018 16:51:23 GMT+0800 (CST)'
console.log('Date: ', interval.next().format('YYYY-MM-DD HH:mm')); // Date:  2018-10-31 01:00
console.log('Date: ', interval.next().format('YYYY-MM-DD HH:mm')); // Date:  2018-11-30 01:00
```