### PR TITLE
core: fix tight loop when crossing DST boundary

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -11,7 +11,7 @@ CronDate.prototype.addMonth = function() {
 };
 
 CronDate.prototype.addDay = function() {
-  this._date.add(1, 'day');
+  this._date.add(1, 'day').startOf('day');
 };
 
 CronDate.prototype.addHour = function() {
@@ -47,7 +47,7 @@ CronDate.prototype.subtractMonth = function() {
 };
 
 CronDate.prototype.subtractDay = function() {
-  this._date.subtract(1, 'day');
+  this._date.subtract(1, 'day').endOf('day');
 };
 
 CronDate.prototype.subtractHour = function() {

--- a/lib/expression.js
+++ b/lib/expression.js
@@ -324,9 +324,9 @@ CronExpression._parseField = function _parseField (field, value, constraints) {
   return parseSequence(value);
 };
 
-CronExpression.prototype._applyTimezoneShift = function(currentDate, method) {
+CronExpression.prototype._applyTimezoneShift = function(currentDate, dateMathVerb, method) {
   var previousHour = currentDate.getHours();
-  currentDate[method]();
+  currentDate[dateMathVerb + method]();
   var currentHour = currentDate.getHours();
   var diff = currentHour - previousHour;
   if (diff === 2) {
@@ -335,15 +335,26 @@ CronExpression.prototype._applyTimezoneShift = function(currentDate, method) {
       // Hour is specified
       this._dstStart = currentHour;
     }
-  } else if ((diff === 0) &&
-             (currentDate.getMinutes() === 0) &&
-             (currentDate.getSeconds() === 0)) {
-    // Ending DST
-    if (this._fields.hour.length !== 24) {
-      // Hour is specified
-      this._dstEnd = currentHour;
+  } else if (diff === 0) {
+    if ((currentDate.getMinutes() === 0) &&
+        (currentDate.getSeconds() === 0)) {
+      if ((method === 'Month') || (method === 'Day')) {
+        currentDate.addHour();
+      } else {
+        // Ending DST
+        if (this._fields.hour.length !== 24) {
+          // Hour is specified
+          this._dstEnd = currentHour;
+        }
+      }
+    } else if ((currentDate.getMinutes() === 59) &&
+               (currentDate.getSeconds() === 59)) {
+      if ((method === 'Month') || (method === 'Day')) {
+        currentDate.subtractHour();
+      }
     }
   }
+
 };
 
 
@@ -459,32 +470,32 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
 
     // Add or subtract day if select day not match with month (according to calendar)
     if (!dayOfMonthMatch && !dayOfWeekMatch) {
-      currentDate[dateMathVerb + 'Day']();
+      this._applyTimezoneShift(currentDate, dateMathVerb, 'Day');
       continue;
     }
 
     // Add or subtract day if not day of month is set (and no match) and day of week is wildcard
     if (!isDayOfMonthWildcardMatch && isDayOfWeekWildcardMatch && !dayOfMonthMatch) {
-      currentDate[dateMathVerb + 'Day']();
+      this._applyTimezoneShift(currentDate, dateMathVerb, 'Day');
       continue;
     }
 
     // Add or subtract day if not day of week is set (and no match) and day of month is wildcard
     if (isDayOfMonthWildcardMatch && !isDayOfWeekWildcardMatch && !dayOfWeekMatch) {
-      currentDate[dateMathVerb + 'Day']();
+      this._applyTimezoneShift(currentDate, dateMathVerb, 'Day');
       continue;
     }
 
     // Add or subtract day if day of month and week are non-wildcard values and both doesn't match
     if (!(isDayOfMonthWildcardMatch && isDayOfWeekWildcardMatch) &&
         !dayOfMonthMatch && !dayOfWeekMatch) {
-      currentDate[dateMathVerb + 'Day']();
+      this._applyTimezoneShift(currentDate, dateMathVerb, 'Day');
       continue;
     }
 
     // Match month
     if (!matchSchedule(currentDate.getMonth() + 1, this._fields.month)) {
-      currentDate[dateMathVerb + 'Month']();
+      this._applyTimezoneShift(currentDate, dateMathVerb, 'Month');
       continue;
     }
 
@@ -492,7 +503,7 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
     if (!matchSchedule(currentHour, this._fields.hour)) {
       if (this._dstStart !== currentHour) {
         this._dstStart = null;
-        this._applyTimezoneShift(currentDate, dateMathVerb + 'Hour');
+        this._applyTimezoneShift(currentDate, dateMathVerb, 'Hour');
         continue;
       } else if (!matchSchedule(currentHour - 1, this._fields.hour)) {
         currentDate[dateMathVerb + 'Hour']();
@@ -501,20 +512,20 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
     } else if (this._dstEnd === currentHour) {
       if (!reverse) {
         this._dstEnd = null;
-        this._applyTimezoneShift(currentDate, 'addHour');
+        this._applyTimezoneShift(currentDate, 'add', 'Hour');
         continue;
       }
     }
 
     // Match minute
     if (!matchSchedule(currentDate.getMinutes(), this._fields.minute)) {
-      this._applyTimezoneShift(currentDate, dateMathVerb + 'Minute');
+      this._applyTimezoneShift(currentDate, dateMathVerb, 'Minute');
       continue;
     }
 
     // Match second
     if (!matchSchedule(currentDate.getSeconds(), this._fields.second)) {
-      this._applyTimezoneShift(currentDate, dateMathVerb + 'Second');
+      this._applyTimezoneShift(currentDate, dateMathVerb, 'Second');
       continue;
     }
 
@@ -522,7 +533,7 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
     // modified
     if (initial_ts === currentDate.getTime()) {
       if ((dateMathVerb === 'add') || (currentDate.getMilliseconds() === 0)) {
-        this._applyTimezoneShift(currentDate, dateMathVerb + 'Second');
+        this._applyTimezoneShift(currentDate, dateMathVerb, 'Second');
       } else {
         currentDate.setMilliseconds(0);
       }

--- a/test/timezone.js
+++ b/test/timezone.js
@@ -403,3 +403,19 @@ test('it will work with #131 issue case', function(t) {
 
   t.end();
 });
+
+test('it will work with #137 issue case', function(t) {
+  var options = {
+    tz: 'America/New_York',
+    currentDate : new Date('10/28/2018')
+  };
+
+  var interval = CronExpression.parse('0 12 * * 3', options);
+  var date = interval.next();
+
+  t.equal(date.getFullYear(), 2018);
+  t.equal(date.getDate(), 31);
+  t.equal(date.getMonth(), 9);
+
+  t.end();
+});


### PR DESCRIPTION
If while adding or substracting dates while looking for the correct
date it's possible to jump into a non-existent date due to DST changes.
Avoid it by adding / substracting an hour.
    
Fixes: https://github.com/harrisiirak/cron-parser/issues/131
Fixes: https://github.com/harrisiirak/cron-parser/issues/137