### PR TITLE
Added .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ logs
 results
 
 npm-debug.log
+
+.idea


### PR DESCRIPTION
Found dir `.idea` in npm package `cron-parser` `v2.2.1`.
The fix will prevent such a situation in the future.