### PR TITLE
Fix Google Apps Script recursive call to parse

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -698,7 +698,7 @@ CronExpression.prototype.reset = function reset () {
  * @param {Object} [options] Parsing options
  * @param {Function} [callback]
  */
-CronExpression.parse = function parse (expression, options, callback) {
+CronExpression.parse = function (expression, options, callback) {
   var self = this;
   if (typeof options === 'function') {
     callback = options;


### PR DESCRIPTION
When using the library on Google Apps Script we faced recursive call to `parse` method in the following code from `lib/expression.js`:

```
CronExpression.parse = function parse (expression, options, callback) {
  var self = this;
  if (typeof options === 'function') {
    callback = options;
    options = {};
  }

  function parse (expression, options) {
    ......

    return new CronExpression(fields, options);
  }

  return parse(expression, options);
};
```

Where 
```
return parse(expression, options);
```

calling wrong parse method.

This simple fix resolves the error.
Let me know if I can improve it.