### PR TITLE
Implement parser loop limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ results
 npm-debug.log
 
 .idea
+.history
 .vscode

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,3 @@
 .idea
+.vscode
+.history

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "cron-parser",
   "repo": "harrisiirak/cron-parser",
   "description": "Node.js library for parsing crontab instructions",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "keywords": ["cron", "crontab", "parser"],
   "dependencies": {},
   "development": {},

--- a/lib/expression.js
+++ b/lib/expression.js
@@ -12,6 +12,25 @@ var safeIsNaN = require('is-nan');
 var LOOP_LIMIT = 10000;
 
 /**
+ * Detect if input range fully matches constraint bounds
+ * @param {Array} range Input range
+ * @param {Array} constraints Input constraints
+ * @returns {Boolean}
+ * @private
+ */
+function isWildcardRange(range, constraints) {
+  if (range instanceof Array && !range.length) {
+    return false;
+  }
+
+  if (constraints.length !== 2) {
+    return false;
+  }
+
+  return range.length === (constraints[1] - (constraints[0] < 1 ? - 1 : 0));
+}
+
+/**
  * Construct a new expression parser
  *
  * Options:
@@ -30,15 +49,9 @@ function CronExpression (fields, options) {
   this._currentDate = new CronDate(options.currentDate, this._tz);
   this._startDate = options.startDate ? new CronDate(options.startDate, this._tz) : null;
   this._endDate = options.endDate ? new CronDate(options.endDate, this._tz) : null;
-  this._fields = {};
+  this._fields = fields;
   this._isIterator = options.iterator || false;
   this._hasIterated = false;
-
-  // Map fields
-  for (var i = 0, c = CronExpression.map.length; i < c; i++) {
-    var key = CronExpression.map[i];
-    this._fields[key] = fields[i];
-  }
 }
 
 /**
@@ -402,25 +415,6 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
     return sequence[0] === value;
   }
 
-  /**
-   * Detect if input range fully matches constraint bounds
-   * @param {Array} range Input range
-   * @param {Array} constraints Input constraints
-   * @returns {Boolean}
-   * @private
-   */
-  function isWildcardRange (range, constraints) {
-    if (range instanceof Array && !range.length) {
-      return false;
-    }
-
-    if (constraints.length !== 2) {
-      return false;
-    }
-
-    return range.length === (constraints[1] - (constraints[0] < 1 ? - 1 : 0));
-  }
-
   // Whether to use backwards directionality when searching
   reverse = reverse || false;
   var dateMathVerb = reverse ? 'subtract' : 'add';
@@ -745,7 +739,24 @@ CronExpression.parse = function parse(expression, options, callback) {
       }
     }
 
-    return new CronExpression(fields, options);
+    var mappedFields = {};
+    for (var i = 0, c = CronExpression.map.length; i < c; i++) {
+      var key = CronExpression.map[i];
+      mappedFields[key] = fields[i];
+    }
+
+    // Validate max daysInMonth value when explicit use
+    if (mappedFields.month.length === 1) {
+      var daysInMonth = CronExpression.daysInMonth[mappedFields.month[0] - 1];
+      var maxDayInMonthValue = Math.max.apply(null, mappedFields.dayOfMonth);
+      var isWildCardDayInMonth = isWildcardRange(mappedFields.dayOfMonth, CronExpression.constraints[3]);
+
+      if (!isWildCardDayInMonth && maxDayInMonthValue > daysInMonth) {
+        throw new Error('Invalid explicit day of month definition');
+      }
+    }
+
+    return new CronExpression(mappedFields, options);
   }
 
   return parse(expression, options);

--- a/lib/expression.js
+++ b/lib/expression.js
@@ -7,6 +7,11 @@ var CronDate = require('./date');
 var safeIsNaN = require('is-nan');
 
 /**
+ * Cron iteration loop safety limit
+ */
+var LOOP_LIMIT = 10000;
+
+/**
  * Construct a new expression parser
  *
  * Options:
@@ -425,9 +430,12 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
   var endDate = this._endDate;
 
   // Find matching schedule
-  var initial_ts = currentDate.getTime();
+  var startTimestamp = currentDate.getTime();
+  var stepCount = 0;
 
-  while (true) {
+  while (stepCount < LOOP_LIMIT) {
+    stepCount++;
+
     // Validate timespan
     if (reverse) {
       if (startDate && (currentDate.getTime() - startDate.getTime() < 0)) {
@@ -457,29 +465,6 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
     var isDayOfWeekWildcardMatch = isWildcardRange(this._fields.dayOfWeek, CronExpression.constraints[5]);
 
     var currentHour = currentDate.getHours();
-
-    // Validate days in month if explicit value is given
-    if (!isDayOfMonthWildcardMatch) {
-      var currentYear = currentDate.getFullYear();
-      var currentMonth = currentDate.getMonth() + 1;
-      var previousMonth = currentMonth === 1 ? 11 : currentMonth - 1;
-      var daysInPreviousMonth = CronExpression.daysInMonth[previousMonth - 1];
-      var daysOfMontRangeMax = this._fields.dayOfMonth[this._fields.dayOfMonth.length - 1];
-
-      var _daysInPreviousMonth = daysInPreviousMonth;
-      var _daysOfMonthRangeMax = daysOfMontRangeMax;
-
-      // Handle leap year
-      var isLeap = !((currentYear % 4) || (!(currentYear % 100) && (currentYear % 400)));
-      if (isLeap) {
-        _daysInPreviousMonth = 29;
-        _daysOfMonthRangeMax = 29;
-      }
-
-      if (this._fields.month[0] === previousMonth && _daysInPreviousMonth < _daysOfMonthRangeMax) {
-        throw new Error('Invalid explicit day of month definition');
-      }
-    }
 
     // Add or subtract day if select day not match with month (according to calendar)
     if (!dayOfMonthMatch && !dayOfWeekMatch) {
@@ -544,7 +529,7 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
 
     // Increase a second in case in the first iteration the currentDate was not
     // modified
-    if (initial_ts === currentDate.getTime()) {
+    if (startTimestamp === currentDate.getTime()) {
       if ((dateMathVerb === 'add') || (currentDate.getMilliseconds() === 0)) {
         this._applyTimezoneShift(currentDate, dateMathVerb, 'Second');
       } else {
@@ -555,6 +540,10 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
     }
 
     break;
+  }
+
+  if (stepCount >= LOOP_LIMIT) {
+    throw new Error('Invalid expression, loop limit exceeded');
   }
 
   this._currentDate = new CronDate(currentDate, this._tz);
@@ -706,7 +695,7 @@ CronExpression.prototype.reset = function reset () {
  * @param {Object} [options] Parsing options
  * @param {Function} [callback]
  */
-CronExpression.parse = function (expression, options, callback) {
+CronExpression.parse = function parse(expression, options, callback) {
   var self = this;
   if (typeof options === 'function') {
     callback = options;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cron-parser",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Node.js library for parsing crontab instructions",
   "main": "lib/parser.js",
   "types": "lib/index.d.ts",

--- a/test/expression.js
+++ b/test/expression.js
@@ -176,11 +176,11 @@ test('invalid expression that contains too many fields', function (t) {
   t.end();
 });
 
-test('invalid expression that is unreachable', function (t) {
-  t.throws(function () {
+test('invalid explicit day of month definition', function(t) {
+  t.throws(function() {
     const iter = CronExpression.parse('0 0 31 4 *');
     iter.next();
-  }, 'Invalid expression, loop limit exceeded');
+  }, 'Invalid explicit day of month definition');
 
   t.end();
 });
@@ -875,24 +875,6 @@ test('day and date in week should matches', function(t){
     t.equal(next.getHours(), 1, 'Hours matches');
     t.ok(next.getDay() === 1 || next.getDate() === 1, 'Day or day of month matches');
 
-  } catch (err) {
-    t.ifError(err, 'Interval parse error');
-  }
-
-  t.end();
-});
-
-test('day of month value can\'t be larger than days in month maximum value if it\'s defined explicitly', function(t) {
-  try {
-    var interval = CronExpression.parse('0 4 31 4 *');
-    t.ok(interval, 'Interval parsed');
-
-    try {
-      interval.next();
-      t.ok(false, 'Should fail');
-    } catch (e) {
-      t.ok(true, 'Failed as expected');
-    }
   } catch (err) {
     t.ifError(err, 'Interval parse error');
   }

--- a/test/expression.js
+++ b/test/expression.js
@@ -176,6 +176,15 @@ test('invalid expression that contains too many fields', function (t) {
   t.end();
 });
 
+test('invalid expression that is unreachable', function (t) {
+  t.throws(function () {
+    const iter = CronExpression.parse('0 0 31 4 *');
+    iter.next();
+  }, 'Invalid expression, loop limit exceeded');
+
+  t.end();
+});
+
 test('incremental minutes expression test', function(t) {
   try {
     var interval = CronExpression.parse('*/3 * * * *');


### PR DESCRIPTION
This PR implements parser loop limit (no infinite loops are possible anymore) and removes culprit day of month validation logic that has been causing some headache. This validation logic was mainly introduced because of an infinite loop that was caused by an invalid day of month value.

Closes #123, closes #127.