### PR TITLE
Adds support for '#' character in the dayOfWeek field

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -519,7 +519,7 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
       this._nthDayOfWeek > 0 &&
       !isNthDayMatch(currentDate, this._nthDayOfWeek)
     ) {
-      this._applyTimezoneShift(currentDate, dateMathVerb, "Day");
+      this._applyTimezoneShift(currentDate, dateMathVerb, 'Day');
       continue;
     }
 

--- a/lib/expression.js
+++ b/lib/expression.js
@@ -52,6 +52,7 @@ function CronExpression (fields, options) {
   this._fields = fields;
   this._isIterator = options.iterator || false;
   this._hasIterated = false;
+  this._nthDayOfWeek = options.nthDayOfWeek || 0;
 }
 
 /**
@@ -415,6 +416,34 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
     return sequence[0] === value;
   }
 
+  /**
+   * Helps determine if the provided date is the correct nth occurence of the
+   * desired day of week.
+   * 
+   * @param {CronDate} date 
+   * @param {Number} nthDayOfWeek 
+   * @return {Boolean}
+   * @private
+   */
+  function isNthDayMatch(date, nthDayOfWeek) {
+    if (nthDayOfWeek < 6) {
+      if (
+        date.getDate() < 8 &&
+        nthDayOfWeek === 1 // First occurence has to happen in first 7 days of the month
+      ) {
+        return true;
+      }
+
+      var offset = date.getDate() % 7 ? 1 : 0; // Math is off by 1 when dayOfWeek isn't divisible by 7
+      var adjustedDate = date.getDate() - (date.getDate() % 7); // find the first occurance
+      var occurrence = Math.floor(adjustedDate / 7) + offset;
+
+      return occurrence === nthDayOfWeek;
+    }
+
+    return false;
+  }
+
   // Whether to use backwards directionality when searching
   reverse = reverse || false;
   var dateMathVerb = reverse ? 'subtract' : 'add';
@@ -482,6 +511,15 @@ CronExpression.prototype._findSchedule = function _findSchedule (reverse) {
     if (!(isDayOfMonthWildcardMatch && isDayOfWeekWildcardMatch) &&
         !dayOfMonthMatch && !dayOfWeekMatch) {
       this._applyTimezoneShift(currentDate, dateMathVerb, 'Day');
+      continue;
+    }
+
+    // Add or subtract day if day of week & nthDayOfWeek are set (and no match)
+    if (
+      this._nthDayOfWeek > 0 &&
+      !isNthDayMatch(currentDate, this._nthDayOfWeek)
+    ) {
+      this._applyTimezoneShift(currentDate, dateMathVerb, "Day");
       continue;
     }
 
@@ -724,16 +762,18 @@ CronExpression.parse = function parse(expression, options, callback) {
       var field = CronExpression.map[i]; // Field name
       var value = atoms[atoms.length > c ? i : i - start]; // Field value
 
-      if (i < start || !value) {
+      if (i < start || !value) { // Use default value
         fields.push(CronExpression._parseField(
           field,
           CronExpression.parseDefaults[i],
           CronExpression.constraints[i])
         );
-      } else { // Use default value
+      } else {
+        var val = field === 'dayOfWeek' ? parseNthDay(value) : value;
+
         fields.push(CronExpression._parseField(
           field,
-          value,
+          val,
           CronExpression.constraints[i])
         );
       }
@@ -757,6 +797,39 @@ CronExpression.parse = function parse(expression, options, callback) {
     }
 
     return new CronExpression(mappedFields, options);
+
+    /**
+     * Parses out the # special character for the dayOfWeek field & adds it to options.
+     * 
+     * @param {String} val 
+     * @return {String}
+     * @private
+     */
+    function parseNthDay(val) {
+      var atoms = val.split('#');
+      if (atoms.length > 1) {
+        var nthValue = +atoms[atoms.length - 1];
+        if(/,/.test(val)) {
+          throw new Error('Constraint error, invalid dayOfWeek `#` and `,` '
+            + 'special characters are incompatible');
+        }
+        if(/\//.test(val)) {
+          throw new Error('Constraint error, invalid dayOfWeek `#` and `/` '
+            + 'special characters are incompatible');
+        }
+        if(/-/.test(val)) {
+          throw new Error('Constraint error, invalid dayOfWeek `#` and `-` '
+            + 'special characters are incompatible');
+        }
+        if (atoms.length > 2 || safeIsNaN(nthValue) || (nthValue < 1 || nthValue > 5)) {
+          throw new Error('Constraint error, invalid dayOfWeek occurrence number (#)');
+        }
+        
+        options.nthDayOfWeek = nthValue;
+        return atoms[0];
+      }
+      return val;
+    }
   }
 
   return parse(expression, options);

--- a/test/expression.js
+++ b/test/expression.js
@@ -1,4 +1,3 @@
-var util = require('util');
 var test = require('tap').test;
 var CronExpression = require('../lib/expression');
 var CronDate = require('../lib/date');

--- a/test/expression.js
+++ b/test/expression.js
@@ -1128,18 +1128,40 @@ test('should work for valid second sunday in may', function(t) {
 test('should work for valid second sunday at noon in may', function(t) {
   try {
     var options = {
-      currentDate: new CronDate('2019-05-12T11:59:00.000Z')
+      currentDate: new CronDate('2019-05-12T11:59:00.000')
     };
-    var expected = new CronDate('2019-05-12T12:00:00.000Z');
+    var expected = new CronDate('2019-05-12T12:00:00.000');
 
     var interval = CronExpression.parse('0 0 12 ? MAY 0#2', options);
     var date = interval.next();
 
-    t.equal(date.getFullYear(), expected.getFullYear(), 'Year matches');
-    t.equal(date.getMonth(), expected.getMonth(), 'Month matches');
-    t.equal(date.getDate(), expected.getDate(), 'Date matches');
-    t.equal(date.getDay(), expected.getDay(), 'Day of Week matches');
-    t.equal(date.getHours(), 12, 'Hour matches');
+    t.equal(
+      date.toISOString(), 
+      expected.toISOString(), 
+      'Expression "0 0 12 ? MAY 0#2" has next() that matches expected: ' + expected.toISOString()
+    );
+  } catch (err) {
+    t.ifError(err, 'Interval parse error');
+  }
+
+  t.end();
+});
+
+test('should work for valid second sunday at noon in may (UTC+3)', function(t) {
+  try {
+    var options = {
+      currentDate: new CronDate('2019-05-12T11:59:00.000', 'Europe/Sofia')
+    };
+    var expected = new CronDate('2019-05-12T12:00:00.000', 'Europe/Sofia');
+
+    var interval = CronExpression.parse('0 0 12 ? MAY 0#2', options);
+    var date = interval.next();
+
+    t.equal(
+      date.toISOString(), 
+      expected.toISOString(), 
+      'Expression "0 0 12 ? MAY 0#2" has next() that matches expected: ' + expected.toISOString()
+    );
   } catch (err) {
     t.ifError(err, 'Interval parse error');
   }

--- a/test/expression.js
+++ b/test/expression.js
@@ -106,7 +106,7 @@ test('default expression (multi-space separated) test 1', function(t) {
 test('value out of the range', function(t) {
   t.throws(function() {
     CronExpression.parse('61 * * * * *');
-  }, 'Constraint error, got value 61 expected range 0-59');
+  }, new Error('Constraint error, got value 61 expected range 0-59'));
 
   t.end();
 });
@@ -114,7 +114,7 @@ test('value out of the range', function(t) {
 test('second value out of the range', function(t) {
   t.throws(function() {
     CronExpression.parse('-1 * * * * *');
-  }, 'Constraint error, got value -1 expected range 0-59');
+  }, new Error('Constraint error, got value -1 expected range 0-59'));
 
   t.end();
 });
@@ -122,7 +122,7 @@ test('second value out of the range', function(t) {
 test('invalid range', function(t) {
   t.throws(function() {
     CronExpression.parse('- * * * * *');
-  }, 'Invalid range: -');
+  }, new Error('Invalid range: -'));
 
   t.end();
 });
@@ -130,7 +130,7 @@ test('invalid range', function(t) {
 test('minute value out of the range', function(t) {
   t.throws(function() {
     CronExpression.parse('* 32,72 * * * *');
-  }, 'Constraint error, got value 72 expected range 0-59');
+  }, new Error('Constraint error, got value 72 expected range 0-59'));
 
   t.end();
 });
@@ -138,7 +138,7 @@ test('minute value out of the range', function(t) {
 test('hour value out of the range', function(t) {
   t.throws(function() {
     CronExpression.parse('* * 12-36 * * *');
-  }, 'Constraint error, got range 12-36 expected range 0-23');
+  }, new Error('Constraint error, got range 12-36 expected range 0-23'));
 
   t.end();
 });
@@ -147,7 +147,7 @@ test('hour value out of the range', function(t) {
 test('day of the month value out of the range', function(t) {
   t.throws(function() {
     CronExpression.parse('* * * 10-15,40 * *');
-  }, 'Constraint error, got value 40 expected range 1-31');
+  }, ('Constraint error, got value 40 expected range 1-31'));
 
   t.end();
 });
@@ -155,7 +155,7 @@ test('day of the month value out of the range', function(t) {
 test('month value out of the range', function(t) {
   t.throws(function() {
     CronExpression.parse('* * * * */10,12-13 *');
-  }, 'Constraint error, got range 12-13 expected range 1-12');
+  }, new Error('Constraint error, got range 12-13 expected range 1-12'));
 
   t.end();
 });
@@ -163,7 +163,7 @@ test('month value out of the range', function(t) {
 test('day of the week value out of the range', function(t) {
   t.throws(function() {
     CronExpression.parse('* * * * * 9');
-  }, 'Constraint error, got value 9 expected range 0-7');
+  }, new Error('Constraint error, got value 9 expected range 0-7'));
 
   t.end();
 });
@@ -171,7 +171,7 @@ test('day of the week value out of the range', function(t) {
 test('invalid expression that contains too many fields', function (t) {
   t.throws(function() {
     CronExpression.parse('* * * * * * * *ASD');
-  }, 'Invalid cron expression');
+  }, new Error('Invalid cron expression'));
 
   t.end();
 });
@@ -180,7 +180,7 @@ test('invalid explicit day of month definition', function(t) {
   t.throws(function() {
     const iter = CronExpression.parse('0 0 31 4 *');
     iter.next();
-  }, 'Invalid explicit day of month definition');
+  }, new Error('Invalid explicit day of month definition'));
 
   t.end();
 });
@@ -223,7 +223,7 @@ test('fixed expression test', function(t) {
 test('invalid characters test - symbol', function(t) {
   t.throws(function() {
     CronExpression.parse('10 ! 12 8 0');
-  }, 'Invalid characters, got value: !');
+  }, new Error('Invalid characters, got value: !'));
 
   t.end();
 });
@@ -231,7 +231,7 @@ test('invalid characters test - symbol', function(t) {
 test('invalid characters test - letter', function(t) {
   t.throws(function() {
     CronExpression.parse('10 x 12 8 0');
-  }, 'Invalid characters, got value: x');
+  }, new Error('Invalid characters, got value: x'));
 
   t.end();
 });
@@ -239,7 +239,7 @@ test('invalid characters test - letter', function(t) {
 test('invalid characters test - parentheses', function(t) {
   t.throws(function() {
     CronExpression.parse('10 ) 12 8 0');
-  }, 'Invalid characters, got value: )');
+  }, new Error('Invalid characters, got value: )'));
 
   t.end();
 });
@@ -247,7 +247,7 @@ test('invalid characters test - parentheses', function(t) {
 test('interval with invalid characters test', function(t) {
   t.throws(function() {
     CronExpression.parse('10 */A 12 8 0');
-  }, 'Invalid characters, got value: */A');
+  }, new Error('Invalid characters, got value: */A'));
 
   t.end();
 });
@@ -255,7 +255,7 @@ test('interval with invalid characters test', function(t) {
 test('range with invalid characters test', function(t) {
   t.throws(function() {
     CronExpression.parse('10 0-z 12 8 0');
-  }, 'Invalid characters, got value: 0-z');
+  }, new Error('Invalid characters, got value: 0-z'));
 
   t.end();
 });
@@ -263,7 +263,7 @@ test('range with invalid characters test', function(t) {
 test('group with invalid characters test', function(t) {
   t.throws(function() {
     CronExpression.parse('10 0,1,z 12 8 0');
-  }, 'Invalid characters, got value: 0,1,z');
+  }, new Error('Invalid characters, got value: 0,1,z'));
 
   t.end();
 });
@@ -271,7 +271,7 @@ test('group with invalid characters test', function(t) {
 test('invalid expression which has repeat 0 times', function(t) {
   t.throws(function() {
     CronExpression.parse('0 */0 * * *');
-  }, 'Constraint error, cannot repeat at every 0 time.');
+  }, new Error('Constraint error, cannot repeat at every 0 time.'));
 
   t.end();
 });
@@ -279,7 +279,7 @@ test('invalid expression which has repeat 0 times', function(t) {
 test('invalid expression which has repeat negative number times', function(t) {
   t.throws(function() {
     CronExpression.parse('0 */-5 * * *');
-  }, 'Constraint error, cannot repeat at every -5 time.');
+  }, new Error('Constraint error, cannot repeat at every -5 time.'));
 
   t.end();
 });

--- a/test/expression.js
+++ b/test/expression.js
@@ -1003,3 +1003,233 @@ test('it will work with #139 issue case', function(t) {
 
   t.end();
 });
+
+test('should work for valid first/second/third/fourth/fifth occurence dayOfWeek (# char)', function(t) {
+  try {
+    var options = {
+      currentDate: new CronDate('2019-04-30')
+    };
+
+    var expectedFirstDates = [
+      new CronDate('2019-05-05'),
+      new CronDate('2019-06-02'),
+      new CronDate('2019-07-07'),
+      new CronDate('2019-08-04')
+    ];
+    var expectedSecondDates = [
+      new CronDate('2019-05-12'),
+      new CronDate('2019-06-9'),
+      new CronDate('2019-07-14'),
+      new CronDate('2019-08-11')
+    ];
+    var expectedThirdDates = [
+      new CronDate('2019-05-19'),
+      new CronDate('2019-06-16'),
+      new CronDate('2019-07-21'),
+      new CronDate('2019-08-18')
+    ];
+    var expectedFourthDates = [
+      new CronDate('2019-05-26'),
+      new CronDate('2019-06-23'),
+      new CronDate('2019-07-28'),
+      new CronDate('2019-08-25')
+    ];
+    var expectedFifthDates = [
+      new CronDate('2019-6-30'),
+      new CronDate('2019-9-29'),
+      new CronDate('2019-12-29'),
+      new CronDate('2020-03-29')
+    ];
+
+    var allExpectedDates = [
+      expectedFirstDates,
+      expectedSecondDates,
+      expectedThirdDates,
+      expectedFourthDates,
+      expectedFifthDates
+    ];
+    var expressions = [
+      '0 0 0 ? * 0#1',
+      '0 0 0 ? * 0#2',
+      '0 0 0 ? * 0#3',
+      '0 0 0 ? * 0#4',
+      '0 0 0 ? * 0#5'
+    ];
+    expressions.forEach(function(expression, index) {
+      var interval = CronExpression.parse(expression, options);
+      var expectedDates = allExpectedDates[index];
+
+      expectedDates.forEach(function(expected) {
+        var date = interval.next();
+        t.equal(
+          date.toISOString(), 
+          expected.toISOString(), 
+          'Expression "' + expression + '" has next() that matches expected: ' + expected.toISOString()
+        );
+      });
+      expectedDates
+        .slice(0, expectedDates.length - 1)
+        .reverse()
+        .forEach(function(expected) {
+          var date = interval.prev();
+          t.equal(
+            date.toISOString(), 
+            expected.toISOString(), 
+            'Expression "' + expression + '" has prev() that matches expected: ' + expected.toISOString()
+          );
+        });
+    });
+  } catch (err) {
+    t.ifError(err, 'Interval parse error');
+  }
+
+  t.end();
+});
+
+test('should work for valid second sunday in may', function(t) {
+  try {
+    var options = {
+      currentDate: new CronDate('2019-01-30')
+    };
+    var expectedDates = [
+      new CronDate('2019-05-12'),
+      new CronDate('2020-05-10'),
+      new CronDate('2021-05-09'),
+      new CronDate('2022-05-08')
+    ];
+
+    var interval = CronExpression.parse('0 0 0 ? MAY 0#2', options);
+    expectedDates.forEach(function(expected) {
+      var date = interval.next();
+      t.equal(
+        date.toISOString(), 
+        expected.toISOString(), 
+        'Expression "0 0 0 ? MAY 0#2" has next() that matches expected: ' + expected.toISOString()
+      );
+    });
+    expectedDates
+      .slice(0, expectedDates.length - 1)
+      .reverse()
+      .forEach(function(expected) {
+        var date = interval.prev();
+        t.equal(
+          date.toISOString(), 
+          expected.toISOString(), 
+          'Expression "0 0 0 ? MAY 0#2" has prev() that matches expected: ' + expected.toISOString()
+        );
+      });
+  } catch (err) {
+    t.ifError(err, 'Interval parse error');
+  }
+
+  t.end();
+});
+
+test('should work for valid second sunday at noon in may', function(t) {
+  try {
+    var options = {
+      currentDate: new CronDate('2019-05-12T11:59:00.000Z')
+    };
+    var expected = new CronDate('2019-05-12T12:00:00.000Z');
+
+    var interval = CronExpression.parse('0 0 12 ? MAY 0#2', options);
+    var date = interval.next();
+
+    t.equal(date.getFullYear(), expected.getFullYear(), 'Year matches');
+    t.equal(date.getMonth(), expected.getMonth(), 'Month matches');
+    t.equal(date.getDate(), expected.getDate(), 'Date matches');
+    t.equal(date.getDay(), expected.getDay(), 'Day of Week matches');
+    t.equal(date.getHours(), 12, 'Hour matches');
+  } catch (err) {
+    t.ifError(err, 'Interval parse error');
+  }
+
+  t.end();
+});
+
+test('should work with both dayOfMonth and nth occurence of dayOfWeek', function(t) {
+  try {
+    var options = {
+      currentDate: new CronDate('2019-04-01')
+    };
+    
+    var expectedDates = [
+      new CronDate('2019-04-16'),
+      new CronDate('2019-04-17'),
+      new CronDate('2019-04-18'),
+      new CronDate('2019-05-15'),
+      new CronDate('2019-05-16'),
+      new CronDate('2019-05-18'),
+    ];
+
+    var interval = CronExpression.parse('0 0 0 16,18 * 3#3', options);
+
+    expectedDates.forEach(function(expected) {
+      var date = interval.next();
+      t.equal(
+        date.toISOString(), 
+        expected.toISOString(), 
+        'Expression "0 0 0 16,18 * 3#3" has next() that matches expected: ' + expected.toISOString()
+      );
+    });
+    expectedDates
+      .slice(0, expectedDates.length - 1)
+      .reverse()
+      .forEach(function(expected) {
+        var date = interval.prev();
+        t.equal(
+          date.toISOString(), 
+          expected.toISOString(), 
+          'Expression "0 0 0 16,18 * 3#3" has prev() that matches expected: ' + expected.toISOString()
+        );
+      });
+  } catch (err) {
+    t.ifError(err, 'Interval parse error');
+  }
+
+  t.end();
+});
+
+test('should error when passed invalid occurence value', function(t) {
+  var expressions = [
+    '0 0 0 ? * 1#',
+    '0 0 0 ? * 1#0',
+    '0 0 0 ? * 4#6',
+    '0 0 0 ? * 0##4',
+  ];
+  expressions.forEach(function(expression) {
+    t.throws(function() {
+      CronExpression.parse(expression);
+    }, new Error('Constraint error, invalid dayOfWeek occurrence number (#)'), expression);
+  });
+  
+  t.end();
+});
+
+// The Quartz documentation says that if the # character is used then no other expression can be used in the dayOfWeek term: http://www.quartz-scheduler.org/api/2.3.0/index.html
+test('cannot combine `-` range and # occurrence special characters', function(t) {
+  var expression = '0 0 0 ? * 2-4#2';
+  t.throws(function() {
+    CronExpression.parse(expression);
+  }, new Error('Constraint error, invalid dayOfWeek `#` and `-` special characters are incompatible'));
+  
+  t.end();
+});
+
+test('cannot combine `/` repeat interval and # occurrence special characters', function(t) {
+  var expression = '0 0 0 ? * 1/2#3';
+  t.throws(function() {
+    CronExpression.parse(expression);
+  }, new Error('Constraint error, invalid dayOfWeek `#` and `/` special characters are incompatible'));
+  
+  t.end();
+});
+
+test('cannot combine `,` list and # occurrence special characters', function(t) {
+  var expression = '0 0 0 ? * 0,6#4';
+  t.throws(function() {
+    CronExpression.parse(expression);
+  }, new Error('Constraint error, invalid dayOfWeek `#` and `,` special characters are incompatible'));
+  
+  t.end();
+});


### PR DESCRIPTION
Since I didn't know all of the cases that @harrisiirak  mentioned in [Issue 124](https://github.com/harrisiirak/cron-parser/issues/124), I borrowed inspiration for the tests from QuartzScheduler's official docs, which say that the # character can not be combined with other expressions in the dayOfWeek field.

I also corrected the usage of the `node-tap` library's `t.throws()` usages to use a proper `Error` object for comparison, as passing just a string would give false positives if it caught an exception with a different message. (I discovered this in my 4th from last test addition, where I'm testing a group of similar expressions for the same error message).