### PR TITLE
Migrated to Day.js from Moment.js.

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -1,208 +1,215 @@
-'use strict';
+"use strict";
 
-var moment = require('moment-timezone');
+var dayjs = require("dayjs");
 
-CronDate.prototype.addYear = function() {
-  this._date.add(1, 'year');
+var utc = require("dayjs/plugin/utc");
+var timezone = require("dayjs/plugin/timezone");
+var badMutable = require("dayjs/plugin/badMutable");
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(badMutable);
+
+CronDate.prototype.addYear = function () {
+  this._date.add(1, "year");
 };
 
-CronDate.prototype.addMonth = function() {
-  this._date.add(1, 'month').startOf('month');
+CronDate.prototype.addMonth = function () {
+  this._date.add(1, "month").startOf("month");
 };
 
-CronDate.prototype.addDay = function() {
-  this._date.add(1, 'day').startOf('day');
+CronDate.prototype.addDay = function () {
+  this._date.add(1, "day").startOf("day");
 };
 
-CronDate.prototype.addHour = function() {
+CronDate.prototype.addHour = function () {
   var prev = this.getTime();
-  this._date.add(1, 'hour').startOf('hour');
+  this._date.add(1, "hour").startOf("hour");
   if (this.getTime() <= prev) {
-    this._date.add(1, 'hour');
+    this._date.add(1, "hour");
   }
 };
 
-CronDate.prototype.addMinute = function() {
+CronDate.prototype.addMinute = function () {
   var prev = this.getTime();
-  this._date.add(1, 'minute').startOf('minute');
+  this._date.add(1, "minute").startOf("minute");
   if (this.getTime() < prev) {
-    this._date.add(1, 'hour');
+    this._date.add(1, "hour");
   }
 };
 
-CronDate.prototype.addSecond = function() {
+CronDate.prototype.addSecond = function () {
   var prev = this.getTime();
-  this._date.add(1, 'second').startOf('second');
+  this._date.add(1, "second").startOf("second");
   if (this.getTime() < prev) {
-    this._date.add(1, 'hour');
+    this._date.add(1, "hour");
   }
 };
 
-CronDate.prototype.subtractYear = function() {
-  this._date.subtract(1, 'year');
+CronDate.prototype.subtractYear = function () {
+  this._date.subtract(1, "year");
 };
 
-CronDate.prototype.subtractMonth = function() {
-  this._date.subtract(1, 'month').endOf('month');
+CronDate.prototype.subtractMonth = function () {
+  this._date.subtract(1, "month").endOf("month");
 };
 
-CronDate.prototype.subtractDay = function() {
-  this._date.subtract(1, 'day').endOf('day');
+CronDate.prototype.subtractDay = function () {
+  this._date.subtract(1, "day").endOf("day");
 };
 
-CronDate.prototype.subtractHour = function() {
+CronDate.prototype.subtractHour = function () {
   var prev = this.getTime();
-  this._date.subtract(1, 'hour').endOf('hour');
+  this._date.subtract(1, "hour").endOf("hour");
   if (this.getTime() >= prev) {
-    this._date.subtract(1, 'hour');
+    this._date.subtract(1, "hour");
   }
 };
 
-CronDate.prototype.subtractMinute = function() {
+CronDate.prototype.subtractMinute = function () {
   var prev = this.getTime();
-  this._date.subtract(1, 'minute').endOf('minute');
+  this._date.subtract(1, "minute").endOf("minute");
   if (this.getTime() > prev) {
-    this._date.subtract(1, 'hour');
+    this._date.subtract(1, "hour");
   }
 };
 
-CronDate.prototype.subtractSecond = function() {
+CronDate.prototype.subtractSecond = function () {
   var prev = this.getTime();
-  this._date.subtract(1, 'second').startOf('second');
+  this._date.subtract(1, "second").startOf("second");
   if (this.getTime() > prev) {
-    this._date.subtract(1, 'hour');
+    this._date.subtract(1, "hour");
   }
 };
 
-CronDate.prototype.getDate = function() {
+CronDate.prototype.getDate = function () {
   return this._date.date();
 };
 
-CronDate.prototype.getFullYear = function() {
+CronDate.prototype.getFullYear = function () {
   return this._date.year();
 };
 
-CronDate.prototype.getDay = function() {
+CronDate.prototype.getDay = function () {
   return this._date.day();
 };
 
-CronDate.prototype.getMonth = function() {
+CronDate.prototype.getMonth = function () {
   return this._date.month();
 };
 
-CronDate.prototype.getHours = function() {
-  return this._date.hours();
+CronDate.prototype.getHours = function () {
+  return this._date.hour();
 };
 
-CronDate.prototype.getMinutes = function() {
+CronDate.prototype.getMinutes = function () {
   return this._date.minute();
 };
 
-CronDate.prototype.getSeconds = function() {
+CronDate.prototype.getSeconds = function () {
   return this._date.second();
 };
 
-CronDate.prototype.getMilliseconds = function() {
+CronDate.prototype.getMilliseconds = function () {
   return this._date.millisecond();
 };
 
-CronDate.prototype.getTime = function() {
+CronDate.prototype.getTime = function () {
   return this._date.valueOf();
 };
 
-CronDate.prototype.getUTCDate = function() {
+CronDate.prototype.getUTCDate = function () {
   return this._getUTC().date();
 };
 
-CronDate.prototype.getUTCFullYear = function() {
+CronDate.prototype.getUTCFullYear = function () {
   return this._getUTC().year();
 };
 
-CronDate.prototype.getUTCDay = function() {
+CronDate.prototype.getUTCDay = function () {
   return this._getUTC().day();
 };
 
-CronDate.prototype.getUTCMonth = function() {
+CronDate.prototype.getUTCMonth = function () {
   return this._getUTC().month();
 };
 
-CronDate.prototype.getUTCHours = function() {
-  return this._getUTC().hours();
+CronDate.prototype.getUTCHours = function () {
+  return this._getUTC().hour();
 };
 
-CronDate.prototype.getUTCMinutes = function() {
+CronDate.prototype.getUTCMinutes = function () {
   return this._getUTC().minute();
 };
 
-CronDate.prototype.getUTCSeconds = function() {
+CronDate.prototype.getUTCSeconds = function () {
   return this._getUTC().second();
 };
 
-CronDate.prototype.toISOString = function() {
+CronDate.prototype.toISOString = function () {
   return this._date.toISOString();
 };
 
-CronDate.prototype.toJSON = function() {
+CronDate.prototype.toJSON = function () {
   return this._date.toJSON();
 };
 
-CronDate.prototype.setDate = function(d) {
+CronDate.prototype.setDate = function (d) {
   return this._date.date(d);
 };
 
-CronDate.prototype.setFullYear = function(y) {
+CronDate.prototype.setFullYear = function (y) {
   return this._date.year(y);
 };
 
-CronDate.prototype.setDay = function(d) {
+CronDate.prototype.setDay = function (d) {
   return this._date.day(d);
 };
 
-CronDate.prototype.setMonth = function(m) {
+CronDate.prototype.setMonth = function (m) {
   return this._date.month(m);
 };
 
-CronDate.prototype.setHours = function(h) {
+CronDate.prototype.setHours = function (h) {
   return this._date.hour(h);
 };
 
-CronDate.prototype.setMinutes = function(m) {
+CronDate.prototype.setMinutes = function (m) {
   return this._date.minute(m);
 };
 
-CronDate.prototype.setSeconds = function(s) {
+CronDate.prototype.setSeconds = function (s) {
   return this._date.second(s);
 };
 
-CronDate.prototype.setMilliseconds = function(s) {
+CronDate.prototype.setMilliseconds = function (s) {
   return this._date.millisecond(s);
 };
 
-CronDate.prototype.getTime = function() {
+CronDate.prototype.getTime = function () {
   return this._date.valueOf();
 };
 
-CronDate.prototype._getUTC = function() {
-  return moment.utc(this._date);
+CronDate.prototype._getUTC = function () {
+  return this._date.utc();
 };
 
-CronDate.prototype.toString = function() {
+CronDate.prototype.toString = function () {
   return this._date.toString();
 };
 
-CronDate.prototype.toDate = function() {
+CronDate.prototype.toDate = function () {
   return this._date.toDate();
 };
 
-function CronDate (timestamp, tz) {
+function CronDate(timestamp, tz) {
   if (timestamp instanceof CronDate) {
     timestamp = timestamp._date;
   }
 
   if (!tz) {
-    this._date = moment(timestamp);
+    this._date = dayjs(timestamp);
   } else {
-    this._date = moment.tz(timestamp, tz);
+    this._date = dayjs.tz(timestamp, tz);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -550,6 +550,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "dayjs": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.1.tgz",
+      "integrity": "sha512-01NCTBg8cuMJG1OQc6PR7T66+AFYiPwgDvdJmvJBn29NGzIG+DIFxPLNjHzwz3cpFIvG+NcwIjP9hSaPVoOaDg=="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -1345,19 +1350,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
-      }
-    },
-    "moment": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
-    },
-    "moment-timezone": {
-      "version": "0.5.31",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
-      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
-      "requires": {
-        "moment": ">= 2.9.0"
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,14 @@
     "test": "test"
   },
   "scripts": {
-    "test": "tap ./test/*.js"
+    "test": "tap ./test/*.js",
+    "testExp": "tap ./test/expression.js",
+    "testBug": "tap ./test/bug.js",
+    "testTz": "tap ./test/timezone.js",
+    "testParser": "tap ./test/parser.js",
+    "testLy": "tap ./test/leap_year.js",
+    "testIofi": "tap ./test/increment_on_first_iteration.js",
+    "test31": "tap ./test/31_of_month.js"
   },
   "repository": {
     "type": "git",
@@ -42,8 +49,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "is-nan": "^1.3.0",
-    "moment-timezone": "^0.5.31"
+    "dayjs": "^1.9.1",
+    "is-nan": "^1.3.0"
   },
   "devDependencies": {
     "sinon": "^7.5.0",


### PR DESCRIPTION
(This should resolve issue #195 )

I have tried to migrate from Moment.js to Day.js, because Moment.js is [no longer being supported](https://momentjs.com/docs/#/-project-status/) and because Day.js has a lot smaller bundle size. See this for comparison: [Day.js bundlephobia](https://bundlephobia.com/result?p=dayjs@1.9.1) vs [Moment.js bundlephobia](https://bundlephobia.com/result?p=moment@2.29.1).

PLEASE NOTE: Not all tests pass - probably because of some difference between Day.js and Moment.js in the way time zones are being handled.
The tests that do not pass are:
 - expression.js from line 1301 to line 1321
 - timezone.js

Perhaps someone can look into these bugs.