### PR TITLE
Expose momentjs format method

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -194,6 +194,10 @@ CronDate.prototype.toDate = function() {
   return this._date.toDate();
 };
 
+CronDate.prototype.format = function(format) {
+    return this._date.format(format);
+  };
+
 CronDate.prototype.isLastDayOfMonth = function() {
   var newDate = this._date.clone();
   //next day

--- a/test/format_date.js
+++ b/test/format_date.js
@@ -1,0 +1,22 @@
+var test = require('tap').test;
+var CronExpression = require('../lib/expression');
+var CronDate = require('../lib/date');
+
+test('default expression test', function(t) {
+    try {
+      var interval = CronExpression.parse('* * * * *');
+      t.ok(interval, 'Interval parsed');
+  
+      var date = new CronDate();
+      var next = interval.next();
+      t.ok(next, 'Found next scheduled interval');
+  
+      var format = 'DD-MM-YYYY';
+      t.equal(next.format(format), date.format(format), 'Schedule matches');
+  
+    } catch (err) {
+      t.ifError(err, 'Interval parse error');
+    }
+  
+    t.end();
+  });


### PR DESCRIPTION
This PR exposes the momentjs `format` method which makes it easier to format the next interval date.