### PR TITLE
Switch from moment-timezone to luxon for smaller bundle

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -1,109 +1,110 @@
 'use strict';
 
-var moment = require('moment-timezone');
+var luxon = require('luxon');
 
 CronDate.prototype.addYear = function() {
-  this._date.add(1, 'year');
+  this._date = this._date.plus({ years: 1 });
 };
 
 CronDate.prototype.addMonth = function() {
-  this._date.add(1, 'month').startOf('month');
+  this._date = this._date.plus({ months: 1 }).startOf('month');
 };
 
 CronDate.prototype.addDay = function() {
-  this._date.add(1, 'day').startOf('day');
+  this._date = this._date.plus({ days: 1 }).startOf('day');
 };
 
 CronDate.prototype.addHour = function() {
-  var prev = this.getTime();
-  this._date.add(1, 'hour').startOf('hour');
-  if (this.getTime() <= prev) {
-    this._date.add(1, 'hour');
+  var prev = this._date
+  this._date = this._date.plus({ hours: 1 }).startOf('hour');
+  if (this._date <= prev) {
+    this._date = this._date.plus({ hours: 1 });
   }
 };
 
 CronDate.prototype.addMinute = function() {
-  var prev = this.getTime();
-  this._date.add(1, 'minute').startOf('minute');
-  if (this.getTime() < prev) {
-    this._date.add(1, 'hour');
+  var prev = this._date;
+  this._date = this._date.plus({ minutes: 1 }).startOf('minute');
+  if (this._date < prev) {
+    this._date = this._date.plus({ hours: 1 });
   }
 };
 
 CronDate.prototype.addSecond = function() {
-  var prev = this.getTime();
-  this._date.add(1, 'second').startOf('second');
-  if (this.getTime() < prev) {
-    this._date.add(1, 'hour');
+  var prev = this._date;
+  this._date = this._date.plus({ seconds: 1 }).startOf('second');
+  if (this._date < prev) {
+    this._date = this._date.plus({ hours: 1 });
   }
 };
 
 CronDate.prototype.subtractYear = function() {
-  this._date.subtract(1, 'year');
+  this._date = this._date.minus({ years: 1 });
 };
 
 CronDate.prototype.subtractMonth = function() {
-  this._date.subtract(1, 'month').endOf('month');
+  this._date = this._date.minus({ months: 1 }).endOf('month');
 };
 
 CronDate.prototype.subtractDay = function() {
-  this._date.subtract(1, 'day').endOf('day');
+  this._date = this._date.minus({ days: 1 }).endOf('day');
 };
 
 CronDate.prototype.subtractHour = function() {
-  var prev = this.getTime();
-  this._date.subtract(1, 'hour').endOf('hour');
-  if (this.getTime() >= prev) {
-    this._date.subtract(1, 'hour');
+  var prev = this._date;
+  this._date = this._date.minus({ hours: 1 }).endOf('hour');
+  if (this._date >= prev) {
+    this._date = this._date.minus({ hours: 1 });
   }
 };
 
 CronDate.prototype.subtractMinute = function() {
-  var prev = this.getTime();
-  this._date.subtract(1, 'minute').endOf('minute');
-  if (this.getTime() > prev) {
-    this._date.subtract(1, 'hour');
+  var prev = this._date;
+  this._date = this._date.minus({ minutes: 1 }).endOf('minute');
+  if (this._date > prev) {
+    this._date = this._date.minus({ hours: 1 });
   }
 };
 
 CronDate.prototype.subtractSecond = function() {
-  var prev = this.getTime();
-  this._date.subtract(1, 'second').startOf('second');
-  if (this.getTime() > prev) {
-    this._date.subtract(1, 'hour');
+  var prev = this._date;
+  this._date = this._date.minus({ seconds: 1 }).startOf('second');
+  if (this._date > prev) {
+    this._date = this._date.minus({ hours: 1 });
   }
 };
 
 CronDate.prototype.getDate = function() {
-  return this._date.date();
+  return this._date.day;
 };
 
 CronDate.prototype.getFullYear = function() {
-  return this._date.year();
+  return this._date.year;
 };
 
 CronDate.prototype.getDay = function() {
-  return this._date.day();
+  var weekday = this._date.weekday;
+  return weekday == 7 ? 0 : weekday;
 };
 
 CronDate.prototype.getMonth = function() {
-  return this._date.month();
+  return this._date.month - 1;
 };
 
 CronDate.prototype.getHours = function() {
-  return this._date.hours();
+  return this._date.hour;
 };
 
 CronDate.prototype.getMinutes = function() {
-  return this._date.minute();
+  return this._date.minute;
 };
 
 CronDate.prototype.getSeconds = function() {
-  return this._date.second();
+  return this._date.second;
 };
 
 CronDate.prototype.getMilliseconds = function() {
-  return this._date.millisecond();
+  return this._date.millisecond;
 };
 
 CronDate.prototype.getTime = function() {
@@ -111,35 +112,36 @@ CronDate.prototype.getTime = function() {
 };
 
 CronDate.prototype.getUTCDate = function() {
-  return this._getUTC().date();
+  return this._getUTC().day;
 };
 
 CronDate.prototype.getUTCFullYear = function() {
-  return this._getUTC().year();
+  return this._getUTC().year;
 };
 
 CronDate.prototype.getUTCDay = function() {
-  return this._getUTC().day();
+  var weekday = this._getUTC().weekday;
+  return weekday == 7 ? 0 : weekday;
 };
 
 CronDate.prototype.getUTCMonth = function() {
-  return this._getUTC().month();
+  return this._getUTC().month - 1;
 };
 
 CronDate.prototype.getUTCHours = function() {
-  return this._getUTC().hours();
+  return this._getUTC().hour;
 };
 
 CronDate.prototype.getUTCMinutes = function() {
-  return this._getUTC().minute();
+  return this._getUTC().minute;
 };
 
 CronDate.prototype.getUTCSeconds = function() {
-  return this._getUTC().second();
+  return this._getUTC().second;
 };
 
 CronDate.prototype.toISOString = function() {
-  return this._date.toISOString();
+  return this._date.toISO();
 };
 
 CronDate.prototype.toJSON = function() {
@@ -147,43 +149,39 @@ CronDate.prototype.toJSON = function() {
 };
 
 CronDate.prototype.setDate = function(d) {
-  return this._date.date(d);
+  this._date = this._date.set({ day: d });
 };
 
 CronDate.prototype.setFullYear = function(y) {
-  return this._date.year(y);
+  this._date = this._date.set({ year: y });
 };
 
 CronDate.prototype.setDay = function(d) {
-  return this._date.day(d);
+  this._date = this._date.set({ weekday: d });
 };
 
 CronDate.prototype.setMonth = function(m) {
-  return this._date.month(m);
+  this._date = this._date.set({ month: m + 1 });
 };
 
 CronDate.prototype.setHours = function(h) {
-  return this._date.hour(h);
+  this._date = this._date.set({ hour: h });
 };
 
 CronDate.prototype.setMinutes = function(m) {
-  return this._date.minute(m);
+  this._date = this._date.set({ minute: m });
 };
 
 CronDate.prototype.setSeconds = function(s) {
-  return this._date.second(s);
+  this._date = this._date.set({ second: s });
 };
 
 CronDate.prototype.setMilliseconds = function(s) {
-  return this._date.millisecond(s);
-};
-
-CronDate.prototype.getTime = function() {
-  return this._date.valueOf();
+  this._date = this._date.set({ millisecond: s });
 };
 
 CronDate.prototype._getUTC = function() {
-  return moment.utc(this._date);
+  return this._date.toUTC();
 };
 
 CronDate.prototype.toString = function() {
@@ -191,25 +189,42 @@ CronDate.prototype.toString = function() {
 };
 
 CronDate.prototype.toDate = function() {
-  return this._date.toDate();
+  return this._date.toJSDate();
 };
 
 CronDate.prototype.isLastDayOfMonth = function() {
-  var newDate = this._date.clone();
   //next day
-  newDate.add(1, 'day').startOf('day');
-  return this._date.month() !== newDate.month();
+  var newDate = this._date.plus({ days: 1 }).startOf('day')
+  return this._date.month !== newDate.month;
 };
 
 function CronDate (timestamp, tz) {
-  if (timestamp instanceof CronDate) {
-    timestamp = timestamp._date;
+  var dateOpts = { zone: tz };
+  if (!timestamp) {
+    this._date = luxon.DateTime.local()
+  } else if (timestamp instanceof CronDate) {
+    this._date = timestamp._date;
+  } else if (timestamp instanceof Date) {
+    this._date = luxon.DateTime.fromJSDate(timestamp, dateOpts);
+  } else if (timestamp instanceof luxon.DateTime) {
+    this._date = timestamp;
+  } else if (typeof timestamp === "number") {
+    this._date = luxon.DateTime.fromMillis(timestamp, dateOpts);
+  } else if (typeof timestamp === "string") {
+    this._date = luxon.DateTime.fromISO(timestamp, dateOpts);
+    this._date.isValid || (this._date = luxon.DateTime.fromRFC2822(timestamp, dateOpts));
+    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, "yyyy-MM-dd HH:mm:ss", dateOpts));
+    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, "EEE, d MMM yyyy HH:mm:ss", dateOpts));
+    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, "yyyy-MM-d", dateOpts));
+    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, "yyyy-M-dd", dateOpts));
   }
 
-  if (!tz) {
-    this._date = moment(timestamp);
-  } else {
-    this._date = moment.tz(timestamp, tz);
+  if (!this._date || !this._date.isValid) {
+    throw new Error("CronDate: unhandled timestamp: " + JSON.stringify(timestamp));
+  }
+  
+  if (tz && tz !== this._date.zoneName) {
+    this._date = this._date.setZone(tz);
   }
 }
 

--- a/lib/date.js
+++ b/lib/date.js
@@ -211,10 +211,9 @@ function CronDate (timestamp, tz) {
   } else if (typeof timestamp === 'string') {
     this._date = luxon.DateTime.fromISO(timestamp, dateOpts);
     this._date.isValid || (this._date = luxon.DateTime.fromRFC2822(timestamp, dateOpts));
-    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, 'yyyy-MM-dd HH:mm:ss', dateOpts));
+    this._date.isValid || (this._date = luxon.DateTime.fromSQL(timestamp, dateOpts));
+    // RFC2822-like format without the required timezone offset (used in tests)
     this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, 'EEE, d MMM yyyy HH:mm:ss', dateOpts));
-    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, 'yyyy-MM-d', dateOpts));
-    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, 'yyyy-M-dd', dateOpts));
   }
 
   if (!this._date || !this._date.isValid) {

--- a/lib/date.js
+++ b/lib/date.js
@@ -206,8 +206,6 @@ function CronDate (timestamp, tz) {
     this._date = timestamp._date;
   } else if (timestamp instanceof Date) {
     this._date = luxon.DateTime.fromJSDate(timestamp, dateOpts);
-  } else if (timestamp instanceof luxon.DateTime) {
-    this._date = timestamp;
   } else if (typeof timestamp === "number") {
     this._date = luxon.DateTime.fromMillis(timestamp, dateOpts);
   } else if (typeof timestamp === "string") {

--- a/lib/date.js
+++ b/lib/date.js
@@ -15,7 +15,7 @@ CronDate.prototype.addDay = function() {
 };
 
 CronDate.prototype.addHour = function() {
-  var prev = this._date
+  var prev = this._date;
   this._date = this._date.plus({ hours: 1 }).startOf('hour');
   if (this._date <= prev) {
     this._date = this._date.plus({ hours: 1 });
@@ -194,31 +194,31 @@ CronDate.prototype.toDate = function() {
 
 CronDate.prototype.isLastDayOfMonth = function() {
   //next day
-  var newDate = this._date.plus({ days: 1 }).startOf('day')
+  var newDate = this._date.plus({ days: 1 }).startOf('day');
   return this._date.month !== newDate.month;
 };
 
 function CronDate (timestamp, tz) {
   var dateOpts = { zone: tz };
   if (!timestamp) {
-    this._date = luxon.DateTime.local()
+    this._date = luxon.DateTime.local();
   } else if (timestamp instanceof CronDate) {
     this._date = timestamp._date;
   } else if (timestamp instanceof Date) {
     this._date = luxon.DateTime.fromJSDate(timestamp, dateOpts);
-  } else if (typeof timestamp === "number") {
+  } else if (typeof timestamp === 'number') {
     this._date = luxon.DateTime.fromMillis(timestamp, dateOpts);
-  } else if (typeof timestamp === "string") {
+  } else if (typeof timestamp === 'string') {
     this._date = luxon.DateTime.fromISO(timestamp, dateOpts);
     this._date.isValid || (this._date = luxon.DateTime.fromRFC2822(timestamp, dateOpts));
-    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, "yyyy-MM-dd HH:mm:ss", dateOpts));
-    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, "EEE, d MMM yyyy HH:mm:ss", dateOpts));
-    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, "yyyy-MM-d", dateOpts));
-    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, "yyyy-M-dd", dateOpts));
+    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, 'yyyy-MM-dd HH:mm:ss', dateOpts));
+    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, 'EEE, d MMM yyyy HH:mm:ss', dateOpts));
+    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, 'yyyy-MM-d', dateOpts));
+    this._date.isValid || (this._date = luxon.DateTime.fromFormat(timestamp, 'yyyy-M-dd', dateOpts));
   }
 
   if (!this._date || !this._date.isValid) {
-    throw new Error("CronDate: unhandled timestamp: " + JSON.stringify(timestamp));
+    throw new Error('CronDate: unhandled timestamp: ' + JSON.stringify(timestamp));
   }
   
   if (tz && tz !== this._date.zoneName) {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 export = CronParser
 
 declare class CronDate {
@@ -51,9 +50,9 @@ declare class CronDate {
 }
 
 interface ParserOptions {
-  currentDate?: string | number | Date | DateTime
-  startDate?: string | number | Date | DateTime
-  endDate?: string | number | Date | DateTime
+  currentDate?: string | number | Date
+  startDate?: string | number | Date
+  endDate?: string | number | Date
   iterator?: boolean
   utc?: boolean
   tz?: string

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 export = CronParser
 
 declare class CronDate {
@@ -50,9 +51,9 @@ declare class CronDate {
 }
 
 interface ParserOptions {
-  currentDate?: string | number | Date
-  startDate?: string | number | Date
-  endDate?: string | number | Date
+  currentDate?: string | number | Date | DateTime
+  startDate?: string | number | Date | DateTime
+  endDate?: string | number | Date | DateTime
   iterator?: boolean
   utc?: boolean
   tz?: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1714,6 +1714,11 @@
         "yallist": "^2.1.2"
       }
     },
+    "luxon": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
+      "integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ=="
+    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -1793,19 +1798,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
-      }
-    },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
-    },
-    "moment-timezone": {
-      "version": "0.5.31",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
-      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
-      "requires": {
-        "moment": ">= 2.9.0"
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "license": "MIT",
   "dependencies": {
     "is-nan": "^1.3.0",
-    "moment-timezone": "^0.5.31"
+    "luxon": "^1.25.0"
   },
   "devDependencies": {
     "eslint": "^7.17.0",

--- a/test/expression.js
+++ b/test/expression.js
@@ -1169,7 +1169,7 @@ test('should work for valid first/second/third/fourth/fifth occurence dayOfWeek 
     ];
     var expectedSecondDates = [
       new CronDate('2019-05-12'),
-      new CronDate('2019-06-9'),
+      new CronDate('2019-06-09'),
       new CronDate('2019-07-14'),
       new CronDate('2019-08-11')
     ];
@@ -1186,8 +1186,8 @@ test('should work for valid first/second/third/fourth/fifth occurence dayOfWeek 
       new CronDate('2019-08-25')
     ];
     var expectedFifthDates = [
-      new CronDate('2019-6-30'),
-      new CronDate('2019-9-29'),
+      new CronDate('2019-06-30'),
+      new CronDate('2019-09-29'),
       new CronDate('2019-12-29'),
       new CronDate('2020-03-29')
     ];

--- a/test/parser_crondate_formats.js
+++ b/test/parser_crondate_formats.js
@@ -133,9 +133,9 @@ test('parse cron date formats with another timezone', (t) => {
   });
 
   test('CronDate with different timezone', (t) => {
-    var date = new CronDate('Mon, 4 Jan 2021 10:00:00', 'Antarctica/McMurdo');
+    var date = new CronDate('Mon, 4 Jan 2021 10:00:00', 'America/New_York');
     var d = new CronDate(date, 'Europe/Athens');
-    t.equal(d.toISOString(), '2021-01-03T23:00:00.000+02:00');
+    t.equal(d.toISOString(), '2021-01-04T17:00:00.000+02:00');
 
     t.end();
   });

--- a/test/parser_crondate_formats.js
+++ b/test/parser_crondate_formats.js
@@ -1,0 +1,144 @@
+var luxon = require('luxon');
+var test = require('tap').test;
+var CronDate = require('../lib/date');
+
+test('parse cron date formats with local timezone', (t) => {
+  // Some tests need the local offset to be compatible without invoking timezone management.
+  // Local offset is dependent on what the system being tested on is
+  var offset = new Date().getTimezoneOffset();
+  var offsetHours = Math.abs(Math.floor(offset/60));
+  var offsetMinutes = offset % 60;
+  var offsetSign = offset < 0 ? '-' : '+';
+
+  var expectedTime = new Date(2021, 0, 4, 10, 0, 0).toString();
+
+  test('undefined date', (t) => {
+    var d = new CronDate();
+
+    t.equal(d.toDate().toString(), new Date().toString());
+
+    t.end();
+  });
+
+  test('JS Date', (t) => {
+    var d = new CronDate(new Date(2021, 0, 4, 10, 0, 0));
+    t.equal(d.toDate().toString(), expectedTime);
+
+    t.end();
+  });
+
+  test('ISO 8601', (t) => {
+    var d = new CronDate('2021-01-04T10:00:00');
+    t.equal(d.toDate().toString(), expectedTime);
+
+    t.end();
+  });
+
+  test('ISO 8601 date', (t) => {
+
+    var d = new CronDate('2021-01-04');
+    var expectedTime = new Date(2021, 0, 4, 0, 0, 0).toString();
+
+    t.equal(d.toDate().toString(), expectedTime);
+
+    t.end();
+  });
+
+  test('RFC2822', (t) => {
+    var offsetString = offsetSign + String(offsetHours).padStart(2, 0) + String(offsetMinutes).padStart(2, 0);
+
+    var d = new CronDate('Mon, 4 Jan 2021 10:00:00 ' + offsetString);
+    t.equal(d.toDate().toString(), expectedTime);
+
+    t.end();
+  });
+
+  test('RFC2822-like without timezone offset', (t) => {
+    var d = new CronDate('Mon, 4 Jan 2021 10:00:00');
+    t.equal(d.toDate().toString(), expectedTime);
+
+    t.end();
+  });
+
+  test('SQL', (t) => {
+    var d = new CronDate('2021-01-04 10:00:00');
+    t.equal(d.toDate().toString(), expectedTime);
+
+    t.end();
+  });
+
+  test('milliseconds', (t) => {
+    var d = new CronDate(new Date('2021-01-04 10:00:00').valueOf());
+    t.equal(d.toDate().toString(), expectedTime);
+
+    t.end();
+  });
+
+  test('CronDate', (t) => {
+    var date = new CronDate('Mon, 4 Jan 2021 10:00:00');
+    var d = new CronDate(date);
+    t.equal(d.toDate().toString(), expectedTime);
+
+    t.end();
+  });
+
+  test('invalid', (t) => {
+    t.throws(() => {
+      var d = new CronDate('2021-01-4 10:00:00');
+    });
+
+    t.end();
+  });
+
+  t.end();
+});
+
+test('parse cron date formats with another timezone', (t) => {
+  test('ISO 8601 without offset', (t) => {
+    // implies format already in timezone
+    var d = new CronDate('2021-01-04T10:00:00', 'Europe/Athens');
+    t.equal(d.toISOString(), '2021-01-04T10:00:00.000+02:00');
+
+    t.end();
+  });
+
+  test('ISO 8601 with non-local offset', (t) => {
+    var d = new CronDate('2021-01-04T10:00:00+01:00', 'Europe/Athens');
+    t.equal(d.toISOString(), '2021-01-04T11:00:00.000+02:00');
+
+    t.end();
+  });
+
+  test('RFC2822 with non-local offset', (t) => {
+    var d = new CronDate('Mon, 4 Jan 2021 10:00:00 +0100', 'Europe/Athens');
+    t.equal(d.toISOString(), '2021-01-04T11:00:00.000+02:00');
+
+    t.end();
+  });
+
+  test('milliseconds', (t) => {
+    var date = luxon.DateTime.fromISO('2021-01-04T11:00:00.000+02:00').valueOf();
+    var d = new CronDate(date, 'Europe/Athens');
+    t.equal(d.toISOString(), '2021-01-04T11:00:00.000+02:00');
+
+    t.end();
+  });
+
+  test('CronDate with same timezone', (t) => {
+    var date = new CronDate('Mon, 4 Jan 2021 10:00:00', 'Europe/Athens');
+    var d = new CronDate(date);
+    t.equal(d.toISOString(), '2021-01-04T10:00:00.000+02:00');
+
+    t.end();
+  });
+
+  test('CronDate with different timezone', (t) => {
+    var date = new CronDate('Mon, 4 Jan 2021 10:00:00', 'Antarctica/McMurdo');
+    var d = new CronDate(date, 'Europe/Athens');
+    t.equal(d.toISOString(), '2021-01-03T23:00:00.000+02:00');
+
+    t.end();
+  });
+
+  t.end('crondate input should');
+});

--- a/test/timezone.js
+++ b/test/timezone.js
@@ -1,5 +1,4 @@
 var test = require('tap').test;
-var luxon = require('luxon');
 var CronExpression = require('../lib/expression');
 
 test('It works on DST start', function(t) {
@@ -214,8 +213,8 @@ test('It works on DST end', function(t) {
     t.equal(date.getDate(), 30, '30th');
 
     options.currentDate = '2016-10-30 00:00:01';
-    // 2016-10-30 03:00:01 in the tz occurs twice, so is non-deterministic, and so get the first occurance
-    options.endDate = luxon.DateTime.fromSQL('2016-10-30 02:00:01', { zone: options.tz }).plus({ hours: 1 }).toJSDate();
+    // specify the DST offset via ISO 8601 format, as 3am is repeated
+    options.endDate = '2016-10-30T03:00:01+03';
 
     interval = CronExpression.parse('0 * * * *', options);
     t.ok(interval, 'Interval parsed');

--- a/test/timezone.js
+++ b/test/timezone.js
@@ -1,4 +1,5 @@
 var test = require('tap').test;
+var luxon = require('luxon');
 var CronExpression = require('../lib/expression');
 
 test('It works on DST start', function(t) {
@@ -213,7 +214,8 @@ test('It works on DST end', function(t) {
     t.equal(date.getDate(), 30, '30th');
 
     options.currentDate = '2016-10-30 00:00:01';
-    options.endDate = '2016-10-30 03:00:01';
+    // 2016-10-30 03:00:01 in the tz occurs twice, so is non-deterministic, and so get the first occurance
+    options.endDate = luxon.DateTime.fromSQL('2016-10-30 02:00:01', { zone: options.tz }).plus({ hours: 1 }).toJSDate();
 
     interval = CronExpression.parse('0 * * * *', options);
     t.ok(interval, 'Interval parsed');


### PR DESCRIPTION
Luxon uses Intl APIs for IANA timezones rather than bundling them

Note: CronDate implemented to support the same types the typescript definitions define, rather than moment's additional array/object timestamp support that could have potentially been used before. - I can add that if necessary

Fixes #195