### PR TITLE
Fix types so that all types are exported

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -79,17 +79,17 @@ declare class CronExpression {
   parse(expression: string, options?: ParserOptions, callback?: () => any): CronExpression
 }
 
-interface StringResult {
+export interface StringResult {
   variables: { [key: string]: string },
   expressions: CronExpression[],
-  errors: { [key: string]: string }
+  errors: { [key: string]: any },
 }
 
 /** Wrapper for CronExpression.parse method */
-export function parseExpression(expression: string, options?: ParserOptions): CronExpression
+export const parseExpression: typeof CronExpression.parse;
 
 /** Parse crontab file */
-export function parseFile(filePath: string, callback: (err: any, data: StringResult) => any): void
+export function parseFile(filePath: string, callback: (err: any, data: StringResult) => void): void;
 
 /** Parse content string */
-export function parseString(data: string): StringResult
+export function parseString(data: string): StringResult;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,6 @@
 declare class CronDate {
+  constructor(timestamp?: CronDate | Date | number | string, tz?: string);
+
   addYear(): void
   addMonth(): void
   addDay(): void
@@ -45,6 +47,8 @@ declare class CronDate {
   getTime(): number
   toString(): string
   toDate(): Date
+
+  isLastDayOfMonth(): boolean;
 }
 
 interface ParserOptions<IsIterable extends boolean> {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,3 @@
-export = CronParser
-
 declare class CronDate {
   addYear(): void
   addMonth(): void
@@ -87,11 +85,11 @@ interface StringResult {
   errors: { [key: string]: string }
 }
 
-declare namespace CronParser {
-  /** Wrapper for CronExpression.parse method */
-  function parseExpression(expression: string, options?: ParserOptions): CronExpression
-  /** Parse crontab file */
-  function parseFile(filePath: string, callback: (err: any, data: StringResult) => any): void
-  /** Parse content string */
-  function parseString(data: string): StringResult
-}
+/** Wrapper for CronExpression.parse method */
+export function parseExpression(expression: string, options?: ParserOptions): CronExpression
+
+/** Parse crontab file */
+export function parseFile(filePath: string, callback: (err: any, data: StringResult) => any): void
+
+/** Parse content string */
+export function parseString(data: string): StringResult

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,7 @@
+type DateTypes = CronDate | Date | number | string;
+
 declare class CronDate {
-  constructor(timestamp?: CronDate | Date | number | string, tz?: string);
+  constructor(timestamp?: DateTypes, tz?: string);
 
   addYear(): void
   addMonth(): void
@@ -52,12 +54,12 @@ declare class CronDate {
 }
 
 interface ParserOptions<IsIterable extends boolean> {
-  currentDate?: string | number | Date
-  startDate?: string | number | Date
-  endDate?: string | number | Date
-  iterator?: IsIterable
-  utc?: boolean
-  tz?: string
+  currentDate?: DateTypes;
+  startDate?: DateTypes;
+  endDate?: DateTypes;
+  iterator?: IsIterable;
+  utc?: boolean;
+  tz?: string;
   nthDayOfWeek?: number;
 }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -47,22 +47,25 @@ declare class CronDate {
   toDate(): Date
 }
 
-interface ParserOptions {
+interface ParserOptions<IsIterable extends boolean> {
   currentDate?: string | number | Date
   startDate?: string | number | Date
   endDate?: string | number | Date
-  iterator?: boolean
+  iterator?: IsIterable
   utc?: boolean
   tz?: string
+  nthDayOfWeek?: number;
 }
 
-declare class CronExpression {
-  constructor(fields: {}, options: {})
+type IteratorResultOrCronDate<IsIterable extends boolean = false> = IsIterable extends true
+  ? IteratorResult<CronDate, CronDate>
+  : CronDate;
 
+declare class CronExpression<IsIterable extends boolean = false> {
   /** Find next suitable date */
-  next(): CronDate
+  next(): IteratorResultOrCronDate<IsIterable>;
   /** Find previous suitable date */
-  prev(): CronDate
+  prev(): IteratorResultOrCronDate<IsIterable>;
 
   /** Check if next suitable date exists */
   hasNext(): boolean
@@ -70,13 +73,13 @@ declare class CronExpression {
   hasPrev(): boolean
 
   /** Iterate over expression iterator */
-  iterate(steps: number, callback?: (item: CronDate, i: number) => any): CronDate[]
+  iterate(steps: number, callback?: (item: IteratorResultOrCronDate<IsIterable>, i: number) => void): IteratorResultOrCronDate<IsIterable>[]
 
   /** Reset expression iterator state */
-  reset(resetDate?: string | number | Date): void
+  reset(resetDate?: CronDate | Date | number | string): void
 
-  /** Parse input expression (async) */
-  parse(expression: string, options?: ParserOptions, callback?: () => any): CronExpression
+  /** Parse input expression */
+  static parse<IsIterable extends boolean = false>(expression: string, options?: ParserOptions<IsIterable>): CronExpression<IsIterable>;
 }
 
 export interface StringResult {

--- a/test/expression.js
+++ b/test/expression.js
@@ -1,4 +1,5 @@
 var test = require('tap').test;
+var t = require('tap');
 var CronExpression = require('../lib/expression');
 var CronDate = require('../lib/date');
 
@@ -965,7 +966,7 @@ test('day of month and week are both set and dow is 6-7', function(t) {
   t.end();
 });
 
-test('day of month validation should be ignored when day of month is wildcard and month is set', function (t) {
+t.only('day of month validation should be ignored when day of month is wildcard and month is set', function (t) {
   try {
     var interval = CronExpression.parse('* * * * 2 *');
     t.ok(interval, 'Interval parsed');


### PR DESCRIPTION
Wrapping in a namespace causes that only the types for those functions are exported.