### PR TITLE
Reset seconds (set milliseconds to 0) when subtracting dates

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -43,16 +43,25 @@ CronDate.prototype.subtractYear = function() {
 };
 
 CronDate.prototype.subtractMonth = function() {
-  this._date = this._date.minus({ months: 1 }).endOf('month');
+  this._date = this._date
+    .minus({ months: 1 })
+    .endOf('month')
+    .startOf('second');
 };
 
 CronDate.prototype.subtractDay = function() {
-  this._date = this._date.minus({ days: 1 }).endOf('day');
+  this._date = this._date
+    .minus({ days: 1 })
+    .endOf('day')
+    .startOf('second');
 };
 
 CronDate.prototype.subtractHour = function() {
   var prev = this._date;
-  this._date = this._date.minus({ hours: 1 }).endOf('hour');
+  this._date = this._date
+    .minus({ hours: 1 })
+    .endOf('hour')
+    .startOf('second');
   if (this._date >= prev) {
     this._date = this._date.minus({ hours: 1 });
   }
@@ -60,7 +69,9 @@ CronDate.prototype.subtractHour = function() {
 
 CronDate.prototype.subtractMinute = function() {
   var prev = this._date;
-  this._date = this._date.minus({ minutes: 1 }).endOf('minute');
+  this._date = this._date.minus({ minutes: 1 })
+    .endOf('minute')
+    .startOf('second');
   if (this._date > prev) {
     this._date = this._date.minus({ hours: 1 });
   }
@@ -68,7 +79,9 @@ CronDate.prototype.subtractMinute = function() {
 
 CronDate.prototype.subtractSecond = function() {
   var prev = this._date;
-  this._date = this._date.minus({ seconds: 1 }).startOf('second');
+  this._date = this._date
+    .minus({ seconds: 1 })
+    .startOf('second');
   if (this._date > prev) {
     this._date = this._date.minus({ hours: 1 });
   }

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,4 +1,3 @@
-var util = require('util');
 var test = require('tap').test;
 var CronParser = require('../lib/parser');
 
@@ -42,18 +41,6 @@ test('no next date', function(t) {
   } catch (err) {
     t.error(err, 'Parse read error');
   }
-
-  t.end();
-});
-
-test('prev with CurrentDate greater than 0ms should work', function(t) {
-  var options = {
-    currentDate: new Date('2017-06-13T18:21:25.002Z')
-  };
-
-  var interval = CronParser.parseExpression('*/5 * * * * *', options);
-  var prev = interval.prev();
-  t.equal(prev.getSeconds(), 25);
 
   t.end();
 });

--- a/test/prev_date.js
+++ b/test/prev_date.js
@@ -1,0 +1,34 @@
+var test = require('tap').test;
+var only = require('tap').only;
+var CronExpression = require('../lib/expression');
+
+only('prev should match correctly (issue #98) when milliseconds are greater than 0', function(t) {
+  var options = {
+    currentDate: new Date('2017-06-13T18:21:25.002Z')
+  };
+
+  var interval = CronExpression.parse('*/5 * * * * *', options);
+  var prev = interval.prev();
+  t.equal(prev.getSeconds(), 25);
+
+  t.end();
+});
+
+only('prev should match correctly (issue #98) when milliseconds are equal to 0', function(t) {
+  var interval = CronExpression.parse('59 59 23 * * *',{
+    currentDate : new Date('2012-12-26 14:38:53')
+  });
+
+  [25, 24, 23, 22].forEach(function(date) {
+    var prev = interval.prev();
+    t.equal(prev.getFullYear(), 2012);
+    t.equal(prev.getMonth(), 11);
+    t.equal(prev.getDate(), date);
+    t.equal(prev.getHours(), 23);
+    t.equal(prev.getMinutes(), 59);
+    t.equal(prev.getSeconds(), 59);
+    console.log('prev', prev.toISOString());
+  });
+
+  t.end();
+});

--- a/test/prev_date.js
+++ b/test/prev_date.js
@@ -1,8 +1,7 @@
 var test = require('tap').test;
-var only = require('tap').only;
 var CronExpression = require('../lib/expression');
 
-only('prev should match correctly (issue #98) when milliseconds are greater than 0', function(t) {
+test('prev should match correctly (issue #98) when milliseconds are greater than 0', function(t) {
   var options = {
     currentDate: new Date('2017-06-13T18:21:25.002Z')
   };
@@ -14,7 +13,7 @@ only('prev should match correctly (issue #98) when milliseconds are greater than
   t.end();
 });
 
-only('prev should match correctly (issue #98) when milliseconds are equal to 0', function(t) {
+test('prev should match correctly (issue #98) when milliseconds are equal to 0', function(t) {
   var interval = CronExpression.parse('59 59 23 * * *',{
     currentDate : new Date('2012-12-26 14:38:53')
   });
@@ -27,7 +26,6 @@ only('prev should match correctly (issue #98) when milliseconds are equal to 0',
     t.equal(prev.getHours(), 23);
     t.equal(prev.getMinutes(), 59);
     t.equal(prev.getSeconds(), 59);
-    console.log('prev', prev.toISOString());
   });
 
   t.end();


### PR DESCRIPTION
Fixes issue with `prev()` returning invalid dates (milliseconds mismatching).

See conclusion: https://github.com/harrisiirak/cron-parser/issues/178#issuecomment-809321798

Fixes #178