### PR TITLE
Remove is-nan dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "is-nan": "^1.3.2",
     "luxon": "^1.26.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove is-nan dependency as it is not used and raise an error in browser since one of its dependencies is using `global`. Fixes #208 