### PR TITLE
Ensure there are only 7 days in a week

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,7 +21,7 @@ export type SixtyRange = Range<0, 30> | Range<30, 60>; // Typescript restriction
 export type HourRange = Range<0, 24>;
 export type DayOfTheMonthRange = Range<1, 32> | 'L';
 export type MonthRange = Range<1, 13>;
-export type DayOfTheWeekRange = Range<0, 8>;
+export type DayOfTheWeekRange = Range<0, 7>;
 
 export type CronFields = {
     readonly second: readonly SixtyRange[];


### PR DESCRIPTION
Unless I'm missing something, Range<0, 8> is 8 days instead of 7, and that would be wrong. I'm sorry I'm not really a JS person, so this is submitted via GitHub and I did not write / run tests.