### PR TITLE
Feature: add support for @annually and @midnight

### DIFF
--- a/lib/expression.js
+++ b/lib/expression.js
@@ -42,14 +42,16 @@ function CronExpression (fields, options) {
 CronExpression.map = [ 'second', 'minute', 'hour', 'dayOfMonth', 'month', 'dayOfWeek' ];
 
 /**
- * Prefined intervals
+ * Predefined intervals
  * @type {Object}
  */
 CronExpression.predefined = {
   '@yearly': '0 0 1 1 *',
+  '@annually': '0 0 1 1 *',
   '@monthly': '0 0 1 * *',
   '@weekly': '0 0 * * 0',
   '@daily': '0 0 * * *',
+  '@midnight': '0 0 * * *',
   '@hourly': '0 * * * *'
 };
 

--- a/test/expression.js
+++ b/test/expression.js
@@ -372,7 +372,26 @@ test('incremental range test with iterator', function(t) {
   t.end();
 });
 
-test('predefined expression', function(t) {
+test('predefined expression @annually', function(t) {
+  try {
+    var interval = CronExpression.parse('@annually');
+    t.ok(interval, 'Interval parsed');
+
+    var date = new CronDate();
+    date.addYear();
+
+    var next = interval.next();
+    t.ok(next, 'Found next scheduled interval');
+
+    t.equal(next.getFullYear(), date.getFullYear(), 'Year matches');
+  } catch (err) {
+    t.error(err, 'Interval parse error');
+  }
+
+  t.end();
+});
+
+test('predefined expression @yearly', function(t) {
   try {
     var interval = CronExpression.parse('@yearly');
     t.ok(interval, 'Interval parsed');
@@ -384,6 +403,25 @@ test('predefined expression', function(t) {
     t.ok(next, 'Found next scheduled interval');
 
     t.equal(next.getFullYear(), date.getFullYear(), 'Year matches');
+  } catch (err) {
+    t.error(err, 'Interval parse error');
+  }
+
+  t.end();
+});
+
+test('predefined expression @midnight', function(t) {
+  try {
+    var interval = CronExpression.parse('@midnight');
+    t.ok(interval, 'Interval parsed');
+
+    var date = new CronDate();
+    date.addDay();
+
+    var next = interval.next();
+    t.ok(next, 'Found next scheduled interval');
+
+    t.equal(next.getDay(), date.getDay(), 'Day matches');
   } catch (err) {
     t.error(err, 'Interval parse error');
   }


### PR DESCRIPTION
This pull request will add support for the `@annually` (`@yearly` alias) and `@midnight` (`@daily` alias) interval.

For more information see: https://en.wikipedia.org/wiki/Cron#Nonstandard_predefined_scheduling_definitions