### PR TITLE
perf(npm): remove superfluous files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-.idea
-.vscode
-.history
-.nyc_output
-node_modules

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,0 @@
-export * from './types'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.1",
   "description": "Node.js library for parsing crontab instructions",
   "main": "lib/parser.js",
-  "types": "index.d.ts",
+  "types": "types/index.d.ts",
   "typesVersions": {
     "<4.1": {
       "*": [
@@ -81,5 +81,11 @@
         "dom"
       ]
     }
-  }
+  },
+  "files": [
+    "lib",
+    "types",
+    "LICENSE",
+    "README.md"
+  ]
 }

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -8,7 +8,7 @@ import {
     parseString,
     fieldsToExpression,
     StringResult
-} from '../index';
+} from '../types';
 
 const interval = parseExpression('0 1 2 3 * 1-3,5');
 const intervalIterator = parseExpression('0 1 2 3 * 1-3,5', {iterator: true});


### PR DESCRIPTION
## Description

This PR reduces the npm package size by 64%, mainly preventing the `test` folder from being published.

I've replaced the `.npmignore` file with the opposite, the `files` section in `package.json` which specifies which files should be published to npm. This is the preferred behavior, as it will automatically filter any useless file not explicitly added to the `files` array.

The root `index.d.ts` has been removed as it wasn't needed, and `package.json` has been adjusted to point types directly to `types/index.d.ts`.

## Motivation

I am considering using this library in another I'm maintaining, and the main blocking point is the package size. If this gets merged, it will instantly become a better option.