### PR TITLE
Worker/Edge runtimes support

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -95,22 +95,4 @@ CronParser.parseString = function parseString (data) {
   return response;
 };
 
-/**
- * Parse crontab file
- *
- * @public
- * @param {String} filePath Path to file
- * @param {Function} callback
- */
-CronParser.parseFile = function parseFile (filePath, callback) {
-  require('fs').readFile(filePath, function(err, data) {
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    return callback(null, CronParser.parseString(data.toString()));
-  });
-};
-
 module.exports = CronParser;

--- a/lib/parser.node.js
+++ b/lib/parser.node.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var CronParser = require('./parser');
+
+/**
+ * Parse crontab file
+ *
+ * @public
+ * @param {String} filePath Path to file
+ * @param {Function} callback
+ */
+CronParser.parseFile = function parseFile (filePath, callback) {
+  require('fs').readFile(filePath, function(err, data) {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    return callback(null, CronParser.parseString(data.toString()));
+  });
+};
+
+module.exports = CronParser;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "cron-parser",
   "version": "4.9.0",
   "description": "Node.js library for parsing crontab instructions",
-  "main": "lib/parser.js",
   "types": "types/index.d.ts",
   "typesVersions": {
     "<4.1": {
@@ -13,6 +12,14 @@
   },
   "directories": {
     "test": "test"
+  },
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "worker": "./lib/parser.js",
+      "browser": "./lib/parser.js",
+      "default": "./lib/parser.node.js"
+    }
   },
   "scripts": {
     "test:tsd": "tsd",

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,5 +1,5 @@
 var test = require('tap').test;
-var CronParser = require('../lib/parser');
+var CronParser = require('../lib/parser.node');
 
 // Globals
 

--- a/test/parser_day_of_month.js
+++ b/test/parser_day_of_month.js
@@ -1,5 +1,5 @@
 var test = require('tap').test;
-var CronParser = require('../lib/parser');
+var CronParser = require('../lib/parser.node');
 
 test('parse cron with last day in a month', function(t) {
   var options = {

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var test = require('tap').test;
-var CronParser = require('../lib/parser');
+var CronParser = require('../lib/parser.node');
 
 test('stringify cron expression all stars no seconds', function (t) {
   try {


### PR DESCRIPTION
If we can add separated entry point in exports, this bring support for browser-like environments

So, this library can be used in:
- [ ] [Vercel Edge Runtime](https://vercel.com/docs/functions/edge-functions/edge-runtime)
- [ ] [CloudFlare Workers](https://workers.cloudflare.com)
- [ ] [Deno](https://deno.com)
- [ ] [Bun](https://bun.sh)