### PR TITLE
add fs/promises to browser import ignore list

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "node": ">=18"
   },
   "browser": {
-    "fs": false
+    "fs": false,
+    "fs/promises": false
   },
   "tsd": {
     "directory": "tests"


### PR DESCRIPTION
With the latest release Webpack builds fail to compile as `fs/promises` is used instead of `fs` in one of the async imports. This PR adds `fs/promises` to the list of ignored browser imports