### PR TITLE
Parse field for day of week should allow 0 or SUN values

### DIFF
--- a/src/CronExpressionParser.ts
+++ b/src/CronExpressionParser.ts
@@ -181,7 +181,7 @@ export class CronExpressionParser {
       value = value.replace(/[a-z]{3}/gi, (match) => {
         match = match.toLowerCase();
         const replacer = Months[match as keyof typeof Months] || DayOfWeek[match as keyof typeof DayOfWeek];
-        if (!replacer) {
+        if (replacer === undefined) {
           throw new Error(`Validation error, cannot resolve alias "${match}"`);
         }
         return replacer.toString();

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -489,6 +489,17 @@ describe('CronExpressionParser', () => {
     expect(next.getMinutes()).toEqual(40);
   });
 
+  test('using day of week string', () => {
+    const interval = CronExpressionParser.parse('15 10 * * SUN');
+    const intervals = interval.take(8);
+    for (const next of intervals) {
+      const day = next.getDay();
+      expect(day === 0).toBeTruthy();
+      expect(next.getHours()).toEqual(10);
+      expect(next.getMinutes()).toEqual(15);
+    }
+  });
+
   test('using days of week strings', () => {
     const interval = CronExpressionParser.parse('15 10 * * MON-TUE');
     const intervals = interval.take(8);


### PR DESCRIPTION
Hi,

Currently expressions like: `0 0 3 * * SUN` are crashing as SUN is parsed as 0 and when field parser checks for replacer existence, instead of checking explicitly for undefined values to throw an error it is checking for any no truthy expression. 0 is a valid value, but not a truthy. Just checking for explicit undefined values should solve the problem. 

