### PR TITLE
Hashed values (H) ranges and steps support

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ The `CronFieldCollection.from` method accepts either CronField instances or raw 
 
 ### Hash support
 
-The library support adding [jitter](https://en.wikipedia.org/wiki/Jitter) to the returned intervals using the `H` special character in a field. When `H` is specified instead of `*`, a random value is used (`H` is replaced by `23`, where 23 is picked randomly, within the valid range of the field).
+The library supports adding [jitter](https://en.wikipedia.org/wiki/Jitter) to the returned intervals using the `H` special character in a field. When `H` is specified instead of `*`, a random value is used (`H` is replaced by `23`, where 23 is picked randomly, within the valid range of the field).
 
 This jitter allows to spread the load when it comes to job scheduling. This feature is inspired by Jenkins's cron syntax.
 
@@ -310,8 +310,17 @@ const interval = CronExpressionParser.parse('30 H * * *');
 // At every minutes of <randomized> hour at <randomized> second everyday.
 const interval = CronExpressionParser.parse('H * H * * *');
 
-// At every 5th minute from <randomized> through 59 everyday.
+// At every 5th minute starting from a random offset.
+// For example, if the random offset is 3, it will run at minutes 3, 8, 13, 18, etc.
 const interval = CronExpressionParser.parse('H/5 * * * *');
+
+// At a random minute within the range 0-10 everyday.
+const interval = CronExpressionParser.parse('H(0-10) * * * *');
+
+// At every 5th minute starting from a random offset within the range 0-4.
+// For example, if the random offset is 2, it will run at minutes 2, 7, 12, 17, etc.
+// The random offset is constrained to be less than the step value.
+const interval = CronExpressionParser.parse('H(0-29)/5 * * * *');
 
 // At every minute of the third <randomized> day of the month
 const interval = CronExpressionParser.parse('* * * * H#3');

--- a/benchmarks/benchmark-inputs.ts
+++ b/benchmarks/benchmark-inputs.ts
@@ -16,4 +16,10 @@ export const benchmarkInputs: BenchmarkInput[] = [
   { pattern: '0 0 0 * * 4,6L', description: 'At midnight on every Thursday and last Saturday of every month' },
   { pattern: '0 0 0 * * 1L,5L', description: 'At midnight on the last Monday and last Friday of every month' },
   { pattern: '0 0 6-20/2,L 2 *', description: 'At midnight on every 2nd hour between 6-20 and last day in February' },
+  { pattern: '0 H * * *', description: 'Every hour on every day of every month' },
+  { pattern: '0 H/3 * * *', description: 'Every 3 hours on every day of every month' },
+  {
+    pattern: 'H H H(9-20)/3 1-11 *',
+    description: 'Every 3 hours between 9am and 8pm on the 1st through 11th months',
+  },
 ];

--- a/src/fields/CronDayOfMonth.ts
+++ b/src/fields/CronDayOfMonth.ts
@@ -23,7 +23,7 @@ export class CronDayOfMonth extends CronField {
     return DAY_CHARS;
   }
   static get validChars(): RegExp {
-    return /^[?,*\dLH/-]+$/;
+    return /^[?,*\dLH/-]+$|^.*H\(\d+-\d+\)\/\d+.*$|^.*H\(\d+-\d+\).*$|^.*H\/\d+.*$/;
   }
   /**
    * CronDayOfMonth constructor. Initializes the "day of the month" field with the provided values.

--- a/src/fields/CronDayOfWeek.ts
+++ b/src/fields/CronDayOfWeek.ts
@@ -24,7 +24,7 @@ export class CronDayOfWeek extends CronField {
   }
 
   static get validChars(): RegExp {
-    return /^[?,*\dLH#/-]+$/;
+    return /^[?,*\dLH#/-]+$|^.*H\(\d+-\d+\)\/\d+.*$|^.*H\(\d+-\d+\).*$|^.*H\/\d+.*$/;
   }
 
   /**

--- a/src/fields/CronField.ts
+++ b/src/fields/CronField.ts
@@ -66,7 +66,7 @@ export abstract class CronField {
    * Returns the regular expression used to validate this field.
    */
   static get validChars(): RegExp {
-    return /^[?,*\dH/-]+$/;
+    return /^[?,*\dH/-]+$|^.*H\(\d+-\d+\)\/\d+.*$|^.*H\(\d+-\d+\).*$|^.*H\/\d+.*$/;
   }
 
   /**

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -1685,7 +1685,29 @@ describe('CronExpressionParser', () => {
     });
   });
 
-  describe('test expressions using the hash extension syntax', () => {
+  describe('test expressions using hashed extension syntax', () => {
+    describe('pattern validation', () => {
+      // Test invalid step value for H/step pattern
+      test('throws error for invalid step in H/step pattern', () => {
+        expect(() => CronExpressionParser.parse('H/0 * * * *')).toThrow('Invalid step: 0, must be positive');
+      });
+
+      // Test invalid range for H(range) pattern
+      test('throws error for invalid range in H(range) pattern', () => {
+        expect(() => CronExpressionParser.parse('H(10-5) * * * *')).toThrow('Invalid range: 10-5, min > max');
+      });
+
+      // Test invalid range for H(range)/step pattern
+      test('throws error for invalid range in H(range)/step pattern', () => {
+        expect(() => CronExpressionParser.parse('H(10-5)/2 * * * *')).toThrow('Invalid range: 10-5, min > max');
+      });
+
+      // Test invalid step for H(range)/step pattern
+      test('throws error for invalid step in H(range)/step pattern', () => {
+        expect(() => CronExpressionParser.parse('H(1-10)/0 * * * *')).toThrow('Invalid step: 0, must be positive');
+      });
+    });
+
     // Not having a seed is making tests less useful
     describe('without a custom seed', () => {
       test('parses expressions using H on all fields', () => {
@@ -1754,7 +1776,10 @@ describe('CronExpressionParser', () => {
           { expression: '* * * H H *', expected: '* * * 12 8 *' },
           { expression: '* * * * H H', expected: '* * * * 8 0' },
           { expression: 'H H H H H H', expected: '5 34 15 12 8 0' },
-          { expression: 'H/5 * * * * *', expected: '5/5 * * * * *' },
+          { expression: 'H/5 * * * * *', expected: '*/5 * * * * *' },
+          { expression: 'H(10-20) * * * *', expected: '0 16 * * * *' },
+          { expression: 'H(0-29)/10 * * * *', expected: '0 5,15,25 * * * *' },
+          { expression: '* H H(9-20)/3 * * 1-5', expected: '* 34 10-19/3 * * 1-5' },
           { expression: '* * * * * H#1', expected: '* * * * * 0#1' },
         ];
 


### PR DESCRIPTION
I've implemented the requested H step and range support from issue #381. 

1. `H/step` syntax - This allows for a random offset (between 0 and step-1) followed by regular steps. For example, `H/5` in the minutes field would pick a random offset between 0-4, and then run at minutes offset, offset+5, offset+10, etc. 

2. `H(range)` syntax - This constrains the random value to a specific range. For example, `H(0-10)` would pick a random minute between 0-10 only.

3. `H(range)/step` syntax - This combines both features, allowing a random offset within a specific range, followed by regular steps. For example, `H(0-29)/5` would pick a random offset between 0-4 within the specified range, then apply the step pattern starting from that offset.

Fixes #381