### PR TITLE
Fix invalid start and end time span validation logic

### DIFF
--- a/tests/CronExpression.test.ts
+++ b/tests/CronExpression.test.ts
@@ -1,4 +1,4 @@
-import { CronExpression, CronExpressionOptions } from '../src/CronExpression';
+import { CronExpression, CronExpressionOptions, TIME_SPAN_OUT_OF_BOUNDS_ERROR_MESSAGE } from '../src/CronExpression';
 import { CronFieldCollection, CronFields } from '../src/CronFieldCollection';
 import { expect } from '@jest/globals';
 import { CronDayOfMonth, CronDayOfWeek, CronHour, CronMinute, CronMonth, CronSecond } from '../src/fields';
@@ -92,6 +92,47 @@ describe('CronExpression', () => {
     });
     const prevDate = cronExpression.prev();
     expect(prevDate.toISOString()).toBe('2020-03-06T10:02:00.000Z');
+  });
+
+  describe('next schedule bounds validation', () => {
+    test('should not throw an error if the current date is within the bounds', () => {
+      const startDate = new Date('2022-01-01T00:00:00Z');
+      const currentDate = new Date('2023-01-01T00:00:00Z');
+      const endDate = new Date('2024-01-01T00:00:00Z');
+      const cronExpression = new CronExpression(fields, {
+        ...options,
+        currentDate,
+        startDate,
+        endDate,
+      });
+      expect(() => cronExpression.next()).not.toThrow();
+      expect(() => cronExpression.prev()).not.toThrow();
+    });
+
+    test('should throw an error if the current date is before the start date', () => {
+      const startDate = new Date('2023-01-01T00:00:00Z');
+      const currentDate = new Date('2022-01-01T00:00:00Z');
+      const cronExpression = new CronExpression(fields, {
+        ...options,
+        currentDate,
+        startDate,
+      });
+
+      expect(() => cronExpression.next()).toThrow(TIME_SPAN_OUT_OF_BOUNDS_ERROR_MESSAGE);
+      expect(() => cronExpression.prev()).toThrow(TIME_SPAN_OUT_OF_BOUNDS_ERROR_MESSAGE);
+    });
+
+    test('should throw an error if the current date is after the end date', () => {
+      const endDate = new Date('2023-01-01T00:00:00Z');
+      const currentDate = new Date('2024-01-01T00:00:00Z');
+      const cronExpression = new CronExpression(fields, {
+        ...options,
+        currentDate,
+        endDate,
+      });
+      expect(() => cronExpression.next()).toThrow(TIME_SPAN_OUT_OF_BOUNDS_ERROR_MESSAGE);
+      expect(() => cronExpression.prev()).toThrow(TIME_SPAN_OUT_OF_BOUNDS_ERROR_MESSAGE);
+    });
   });
 
   describe('stringify', () => {

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -1,5 +1,5 @@
 import CronDate from '../src/CronDate';
-import { CronExpression, CronExpressionOptions } from '../src/CronExpression';
+import { CronExpression, CronExpressionOptions, TIME_SPAN_OUT_OF_BOUNDS_ERROR_MESSAGE } from '../src/CronExpression';
 import { CronExpressionParser } from '../src/CronExpressionParser';
 import { CronFieldCollection } from '../src/CronFieldCollection';
 
@@ -1231,8 +1231,7 @@ describe('CronExpressionParser', () => {
       expect(next.getHours()).toEqual(4); // 4 AM
       expect(next.getDate()).toEqual(27); // on the 27th
 
-      // Out of the timespan range
-      expect(() => interval.next()).toThrow();
+      expect(() => interval.next()).toThrow(TIME_SPAN_OUT_OF_BOUNDS_ERROR_MESSAGE);
     });
 
     test('It works on DST end 2016-10-30 02:00:01 - 0 * * * *', () => {
@@ -1370,8 +1369,7 @@ describe('CronExpressionParser', () => {
       expect(next.getHours()).toEqual(3); // 3 AM
       expect(next.getDate()).toEqual(30); // on the 30th
 
-      // Out of the timespan range
-      expect(() => interval.next()).toThrow();
+      expect(() => interval.next()).toThrow(TIME_SPAN_OUT_OF_BOUNDS_ERROR_MESSAGE);
 
       options.endDate = '2016-10-30 04:00:01';
 
@@ -1398,8 +1396,7 @@ describe('CronExpressionParser', () => {
       expect(next.getHours()).toEqual(4); // 4 AM
       expect(next.getDate()).toEqual(30); // on the 30th
 
-      // Out of the timespan range
-      expect(() => interval.next()).toThrow();
+      expect(() => interval.next()).toThrow(TIME_SPAN_OUT_OF_BOUNDS_ERROR_MESSAGE);
 
       options.currentDate = new Date('Sun Oct 29 2016 01:00:00 GMT+0200');
       options.endDate = undefined;


### PR DESCRIPTION
This PR fixes issues with time span validation related to the provided `startDate`, `endDate`, and `currentDate` values. Previously, the validation was not applied correctly, allowing operations with a `currentDate` value that was actually out of bounds.

Fixes #357