### PR TITLE
Update CronDate addSecond and subtractSecond to set milliseconds to 0

### DIFF
--- a/src/CronDate.ts
+++ b/src/CronDate.ts
@@ -169,7 +169,7 @@ export class CronDate {
    * Adds one second to the current CronDate.
    */
   addSecond(): void {
-    this.#date = this.#date.plus({ seconds: 1 });
+    this.#date = this.#date.plus({ seconds: 1 }).startOf('second');
   }
 
   /**
@@ -216,7 +216,7 @@ export class CronDate {
    * If the second is 0, it will subtract one minute instead.
    */
   subtractSecond(): void {
-    this.#date = this.#date.minus({ seconds: 1 });
+    this.#date = this.#date.minus({ seconds: 1 }).startOf('second');
   }
 
   /**


### PR DESCRIPTION
### Overview
This PR fixes an issue where using the CronExpressionParser to parse the next scheduled time yielded an `Out of the timespan range` error when `currentDate` and `endDate` where milliseconds apart. Since cron expressions don't need to worry about milliseconds and we set milliseconds to 0 for other `addUnit` operations, it seems reasonable to apply this to the seconds operations as well.

### Issue
It appears that when using `addSecond` to go to the next time candidate, the milliseconds are preserved. This causes potential candidates to be skipped over in specific cases like when trying to schedule every minute.

### Failing example
```ts
import {CronExpressionParser} from "cron-parser";

const scheduledTime = new Date("2025-08-21T17:16:00.000Z");
const cron = "* * * * *";

// 2025-08-21T17:15:59.999Z
const instantBeforeTrigger = new Date(
  scheduledTime.getTime() - 1,
).toISOString();

// 2025-08-21T17:16:00.001Z
const instantAfterTrigger = new Date(scheduledTime.getTime() + 1).toISOString();

// Expected: 2025-08-21T17:16:00.000Z, Got: Out of the timespan range
const nextTime = CronExpressionParser.parse(cron, {
  currentDate: instantBeforeTrigger,
  endDate: instantAfterTrigger,
  tz: "America/New_York",
})
  .next()
  .toISOString();
```