### PR TITLE
fix: stop hour-step loop early on spring-forward DST days to prevent day skip

### DIFF
--- a/src/CronExpression.ts
+++ b/src/CronExpression.ts
@@ -471,6 +471,10 @@ export class CronExpression {
       const steps = reverse ? currentHour - nextHour : nextHour - currentHour;
       for (let i = 0; i < steps; i++) {
         currentDate.applyDateOperation(dateMathVerb, TimeUnit.Hour, hours.length);
+        // On spring-forward days, one step jumps 2 wall-clock hours (e.g. 01:00 → 03:00),
+        // which can overshoot the target hour. Stop as soon as we reach or pass it.
+        if (!reverse && currentDate.getHours() >= nextHour) break;
+        if (reverse && currentDate.getHours() <= nextHour) break;
       }
     } else {
       currentDate.setHours(nextHour);

--- a/src/CronExpression.ts
+++ b/src/CronExpression.ts
@@ -471,8 +471,7 @@ export class CronExpression {
       const steps = reverse ? currentHour - nextHour : nextHour - currentHour;
       for (let i = 0; i < steps; i++) {
         currentDate.applyDateOperation(dateMathVerb, TimeUnit.Hour, hours.length);
-        // On spring-forward days, one step jumps 2 wall-clock hours (e.g. 01:00 → 03:00),
-        // which can overshoot the target hour. Stop as soon as we reach or pass it.
+        // Overshoot protection: a spring-forward step can jump 2 wall-clock hours.
         if (!reverse && currentDate.getHours() >= nextHour) break;
         if (reverse && currentDate.getHours() <= nextHour) break;
       }

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -1592,11 +1592,7 @@ describe('CronExpressionParser', () => {
       expect(prev.getMinutes()).toEqual(0);
     });
 
-    test('does not skip spring-forward DST day when targeted by day-of-week', () => {
-      // March 8, 2026 is the US spring-forward day (America/Chicago clocks jump 01:00→03:00).
-      // currentDate is Saturday night (23:45 CST = 05:45 UTC Sunday).
-      // The cron targets Sundays at 8am; the library was incorrectly skipping the DST day
-      // entirely and returning the following Sunday instead.
+    test('does not overshoot target hour on spring-forward DST day (forward)', () => {
       const options: CronExpressionOptions = {
         tz: 'America/Chicago',
         currentDate: new Date('2026-03-08T05:45:00.000Z'), // 11:45 PM CST Sat Mar 7
@@ -1606,7 +1602,20 @@ describe('CronExpressionParser', () => {
       const next = interval.next();
 
       expect(next).toBeInstanceOf(CronDate);
-      expect(next.toISOString()).toEqual('2026-03-08T13:00:00.000Z'); // 8am CDT Sun Mar 8 (UTC-5)
+      expect(next.toISOString()).toEqual('2026-03-08T13:00:00.000Z'); // 8am CDT Sun Mar 8
+    });
+
+    test('does not overshoot target hour on spring-forward DST day (reverse)', () => {
+      const options: CronExpressionOptions = {
+        tz: 'America/Chicago',
+        currentDate: new Date('2026-03-08T23:00:00.000Z'), // 6pm CDT Sun Mar 8
+      };
+
+      const interval = CronExpressionParser.parse('0 8 * * 0', options);
+      const prev = interval.prev();
+
+      expect(prev).toBeInstanceOf(CronDate);
+      expect(prev.toISOString()).toEqual('2026-03-08T13:00:00.000Z'); // 8am CDT Sun Mar 8
     });
   });
 

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -1591,6 +1591,23 @@ describe('CronExpressionParser', () => {
       expect([2, 3]).toContain(prev.getHours());
       expect(prev.getMinutes()).toEqual(0);
     });
+
+    test('does not skip spring-forward DST day when targeted by day-of-week', () => {
+      // March 8, 2026 is the US spring-forward day (America/Chicago clocks jump 01:00→03:00).
+      // currentDate is Saturday night (23:45 CST = 05:45 UTC Sunday).
+      // The cron targets Sundays at 8am; the library was incorrectly skipping the DST day
+      // entirely and returning the following Sunday instead.
+      const options: CronExpressionOptions = {
+        tz: 'America/Chicago',
+        currentDate: new Date('2026-03-08T05:45:00.000Z'), // 11:45 PM CST Sat Mar 7
+      };
+
+      const interval = CronExpressionParser.parse('0 8 * * 0', options);
+      const next = interval.next();
+
+      expect(next).toBeInstanceOf(CronDate);
+      expect(next.toISOString()).toEqual('2026-03-08T13:00:00.000Z'); // 8am CDT Sun Mar 8 (UTC-5)
+    });
   });
 
   describe('test expressions with "L" last of flag', () => {


### PR DESCRIPTION
## Bug

On spring-forward DST transition days, `next()` skips the entire day when the cron expression targets that day via day-of-week, returning the following week instead.

**Minimal repro** (US spring-forward, March 8 2026):

```js
const { CronExpressionParser } = require('cron-parser');

const interval = CronExpressionParser.parse('0 8 * * 0', {
  tz: 'America/Chicago',
  currentDate: new Date('2026-03-08T05:45:00.000Z'), // 11:45 PM CST Sat Mar 7
});

console.log(interval.next().toISOString());
// Expected: '2026-03-08T13:00:00.000Z'  (8am CDT Sun Mar 8)
// Got:      '2026-03-15T13:00:00.000Z'  (skips DST day, returns following Sunday)
```

## Root Cause

In `#matchHour` (`CronExpression.ts`), when the current date falls on a DST transition day, the code steps hour-by-hour instead of directly setting the target hour. The number of steps is computed as `nextHour - currentHour` in local wall-clock time.

On a spring-forward day, one `applyDateOperation(Add, Hour)` call jumps **2 wall-clock hours** (e.g. `01:00 → 03:00`), so the loop overshoots the target by 1 hour:

- Steps calculated: `8 - 0 = 8`
- i=0: `00:00 → 01:00`
- i=1: `01:00 → 03:00` ← DST jump (2 hours)
- i=2..6: `03→04→05→06→07→08`
- i=7: **`08:00 → 09:00`** ← overshoot!

Now at `09:00`, `findNearestValue(9)` on `[8]` returns `null` → the code jumps a full day → repeats until the next Sunday.

## Fix

Break out of the stepping loop as soon as the current hour reaches or passes the target:

```ts
for (let i = 0; i < steps; i++) {
  currentDate.applyDateOperation(dateMathVerb, TimeUnit.Hour, hours.length);
  // On spring-forward days, one step can jump 2 wall-clock hours and overshoot.
  if (!reverse && currentDate.getHours() >= nextHour) break;
  if (reverse && currentDate.getHours() <= nextHour) break;
}
```

## Tests

Added a regression test in `CronExpressionParser.test.ts` covering this exact scenario. All 264 existing tests continue to pass.