### PR TITLE
fix: do not reject an out-of-range day of month when the day of week is restricted

### DIFF
--- a/src/CronFieldCollection.ts
+++ b/src/CronFieldCollection.ts
@@ -158,7 +158,10 @@ export class CronFieldCollection {
       throw new Error('Validation error, Field dayOfWeek is missing');
     }
 
-    if (month.values.length === 1 && !dayOfMonth.hasLastChar) {
+    // Only an explicit day of month that can never occur is invalid. When the
+    // day of week is restricted it rescues the expression (day of month and day
+    // of week combine with OR), so the day of month need not be reachable.
+    if (month.values.length === 1 && !dayOfMonth.hasLastChar && dayOfWeek.isWildcard) {
       if (!(parseInt(dayOfMonth.values[0] as string, 10) <= CronMonth.daysInMonth[month.values[0] - 1])) {
         throw new Error('Invalid explicit day of month definition');
       }

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -68,6 +68,17 @@ describe('CronExpressionParser', () => {
       }).toThrow('Invalid explicit day of month definition');
     });
 
+    test('explicit day of month rescued by a restricted day of week', () => {
+      // Day of month and day of week combine with OR, so an out-of-range day of
+      // month is valid when the day of week is restricted: it fires on the
+      // matching weekdays.
+      const iter = CronExpressionParser.parse('0 0 31 2 1-5');
+      const next = iter.next();
+      expect(next.getMonth()).toEqual(1); // February
+      expect(next.getDay()).toBeGreaterThanOrEqual(1);
+      expect(next.getDay()).toBeLessThanOrEqual(5);
+    });
+
     test('invalid characters test - symbol', () => {
       expect(() => CronExpressionParser.parse('10 ! 12 8 0')).toThrow('Invalid characters, got value: !');
     });

--- a/tests/CronFieldCollection.test.ts
+++ b/tests/CronFieldCollection.test.ts
@@ -181,9 +181,25 @@ describe('CronFieldCollection', () => {
             hour: new CronHour([12]),
             dayOfMonth: new CronDayOfMonth([31]), // February only has 28/29 days
             month: new CronMonth([2]), // February
-            dayOfWeek: new CronDayOfWeek([1]),
+            dayOfWeek: new CronDayOfWeek([0, 1, 2, 3, 4, 5, 6], { wildcard: true }), // '*', no day-of-week rescue
           }),
       ).toThrow('Invalid explicit day of month definition');
+    });
+
+    test('should not throw when an out-of-range day of month is rescued by the day of week', () => {
+      // Day of month and day of week combine with OR, so 31 February with a
+      // restricted day of week is valid: it fires on those weekdays.
+      expect(
+        () =>
+          new CronFieldCollection({
+            second: new CronSecond([0]),
+            minute: new CronMinute([0]),
+            hour: new CronHour([12]),
+            dayOfMonth: new CronDayOfMonth([31]),
+            month: new CronMonth([2]),
+            dayOfWeek: new CronDayOfWeek([1]), // Monday
+          }),
+      ).not.toThrow();
     });
   });
 


### PR DESCRIPTION
### Problem

Day of month and day of week combine with **OR** (a date matches when *either* field matches). So an explicit day of month that can never occur in the only configured month is still valid when the day of week is restricted — the expression simply fires on the matching weekdays. But parsing throws:

```js
CronExpressionParser.parse('0 0 31 2 1-5');
// Error: Invalid explicit day of month definition

CronExpressionParser.parse('0 0 30 2 0');
// Error: Invalid explicit day of month definition
```

`31 2 1-5` means "the 31st **or** any Mon–Fri, in February" — valid, and the engine already evaluates it correctly at runtime (`#matchDayOfMonth` honours the OR semantics). Only the construction-time pre-flight guard in `CronFieldCollection` rejects it.

Note the inconsistency: the multi-month form `0 0 31 2,4 1-5` (which skips the `month.values.length === 1` guard) parses and fires fine — only the single-month form was wrongly rejected.

### Fix

The guard only makes sense when nothing can rescue the unreachable day of month, i.e. when the day of week is a wildcard. Add `dayOfWeek.isWildcard` to the condition:

```ts
if (month.values.length === 1 && !dayOfMonth.hasLastChar && dayOfWeek.isWildcard) {
  // ... throw on an impossible explicit day of month
}
```

`0 0 31 2 *` (no day-of-week rescue) still throws; `0 0 31 2 1-5` now parses and fires on weekdays in February.

### Tests

- Updated the existing `CronFieldCollection` throw test to use a wildcard day of week (the genuinely-invalid case).
- Added tests that a restricted day of week rescues the out-of-range day of month (`CronFieldCollection` + `CronExpressionParser`).

`TZ=UTC` full suite green (267/267), lint + `tsc` clean.

---

Separately, I also found that an impossible **multi-month** expression like `0 0 31 2,4 *` (no rescue possible) silently returns out-of-field dates from `next()` instead of throwing — a loop-limit off-by-one in `CronExpression`. Happy to open a second PR for that if useful; kept it out of this one to stay focused on a single root cause.