### PR TITLE
fix: keep explicit range bounds when stringifying stepped fields (#279)

### DIFF
--- a/src/CronFieldCollection.ts
+++ b/src/CronFieldCollection.ts
@@ -331,11 +331,10 @@ export class CronFieldCollection {
   /**
    * Handles multiple ranges.
    * @param {FieldRange} range {start: number, end: number, step: number, count: number} The range to handle.
-   * @param {number} max The maximum value for the field.
    * @returns {string} The stringified range.
    * @private
    */
-  static #handleMultipleRanges(range: FieldRange, max: number): string {
+  static #handleMultipleRanges(range: FieldRange): string {
     const step = range.step;
     if (step === 1) {
       return `${range.start}-${range.end}`;
@@ -368,7 +367,7 @@ export class CronFieldCollection {
         .join(',');
     }
 
-    return range.end === max - step + 1 ? `${range.start}/${step}` : `${range.start}-${range.end}/${step}`;
+    return `${range.start}-${range.end}/${step}`;
   }
 
   /**
@@ -398,8 +397,7 @@ export class CronFieldCollection {
     }
     return ranges
       .map((range) => {
-        const value =
-          range.count === 1 ? range.start.toString() : CronFieldCollection.#handleMultipleRanges(range, max);
+        const value = range.count === 1 ? range.start.toString() : CronFieldCollection.#handleMultipleRanges(range);
         if (field instanceof CronDayOfWeek && field.nthDay > 0) {
           return `${value}#${field.nthDay}`;
         }

--- a/tests/CronExpression.test.ts
+++ b/tests/CronExpression.test.ts
@@ -405,7 +405,7 @@ describe('CronExpression', () => {
     });
 
     test('stringify cron expression with semi range step', () => {
-      const expected = '0 5/5 * * * *';
+      const expected = '0 5-55/5 * * * *';
       const interval = CronExpressionParser.parse('5/5 * * * *', {});
       let str = interval.stringify(true);
       expect(str).toEqual(expected);
@@ -414,12 +414,33 @@ describe('CronExpression', () => {
     });
 
     test('stringify cron expression with semi range step (discard seconds)', () => {
-      const expected = '5/5 * * * *';
+      const expected = '5-55/5 * * * *';
       const interval = CronExpressionParser.parse('5/5 * * * *', {});
       let str = interval.stringify();
       expect(str).toEqual(expected);
       str = CronExpression.fieldsToExpression(interval.fields).stringify();
       expect(str).toEqual(expected);
+    });
+
+    // https://github.com/harrisiirak/cron-parser/issues/279
+    // A stepped range whose end coincides with `max - step + 1` must keep its
+    // explicit range bounds. Emitting the bare `start/step` shorthand produces a
+    // non-standard expression (crontab(5) only allows `*/step` or `first-last/step`)
+    // that other parsers reject when `start` is not the field minimum.
+    test('stringify keeps explicit range bounds for stepped ranges not starting at min', () => {
+      // All inputs are five-field expressions, so `stringify()` (no seconds) is used.
+      const cases: [string, string][] = [
+        ['0 6-18/6 * * *', '0 6-18/6 * * *'], // hours 6,12,18 (end === max - step + 1)
+        ['0 3,6,9,12,15,18,21 * * *', '0 3-21/3 * * *'], // produced invalid "3/3" before
+        ['0 0 2/2 * *', '0 0 2-30/2 * *'], // day-of-month 2,4,...,30
+      ];
+      for (const [input, expected] of cases) {
+        const stringified = CronExpressionParser.parse(input).stringify();
+        expect(stringified).toEqual(expected);
+        // Re-parsing the output and stringifying again must be stable (round-trips
+        // to the same expression), proving no value information was lost.
+        expect(CronExpressionParser.parse(stringified).stringify()).toEqual(expected);
+      }
     });
 
     test('stringify cron expression with L', () => {

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -1850,7 +1850,7 @@ describe('CronExpressionParser', () => {
           { expression: 'H(10-20) * * * *', expected: '0 16 * * * *' },
           { expression: 'H(0-29)/10 * * * *', expected: '0 5,15,25 * * * *' },
           { expression: 'H(5-10)/3 * * * * *', expected: '6,9 * * * * *' },
-          { expression: '0 0 0 H/2 * *', expected: '0 0 0 2/2 * *' },
+          { expression: '0 0 0 H/2 * *', expected: '0 0 0 2-30/2 * *' },
           { expression: '* H H(9-20)/3 * * 1-5', expected: '* 34 10-19/3 * * 1-5' },
           { expression: '* * * * * H#1', expected: '* * * * * 0#1' },
         ];


### PR DESCRIPTION
Fixes #279

## Problem

`stringify()` produces non-standard cron expressions for stepped ranges that do not start at the field minimum. The `start/step` shorthand is emitted whenever a range happens to end at `max - step + 1`:

```js
const { CronExpressionParser } = require("cron-parser");

CronExpressionParser.parse("0 6-18/6 * * *").stringify();
// => "0 6/6 * * *"   (expected "0 6-18/6 * * *")

CronExpressionParser.parse("0 3,6,9,12,15,18,21 * * *").stringify();
// => "0 3/3 * * *"   (expected "0 3-21/3 * * *")
```

Per [`crontab(5)`](https://man7.org/linux/man-pages/man5/crontab.5.html), step values are only allowed after `*` (`*/step`) or an explicit range (`first-last/step`). A bare `start/step` such as `6/6` or `3/3` is not a documented form, and stricter parsers reject it. As reported in the issue, `croner` throws:

> `CronPattern: Syntax error, stepping with numeric prefix ('3/3') is not allowed. Use wildcard (*/step) or range (min-max/step) instead.`

## Root cause

In `CronFieldCollection.#handleMultipleRanges`:

```ts
return range.end === max - step + 1 ? `${range.start}/${step}` : `${range.start}-${range.end}/${step}`;
```

The `range.end === max - step + 1` branch drops the explicit upper bound. That shorthand is only equivalent to `*/step` when `range.start` is the field minimum — but that full-coverage case is already handled by `#handleSingleRange` (which returns `*/step`). For any other start value the shorthand is wrong/non-portable. The bug has existed since the range-step stringify logic was introduced (carried into the TS rewrite).

## Fix

Always emit the explicit, spec-compliant `start-end/step` form. It is portable and round-trips to the same set of values. The `*/step` full-coverage case is unaffected (handled in `#handleSingleRange`). The now-unused `max` parameter was removed from `#handleMultipleRanges`.

## Tests

- Added a regression test (`tests/CronExpression.test.ts`) covering the exact issue cases plus a round-trip stability check; it fails on `master` (produces `6/6`, `3/3`, `2/2`) and passes with the fix.
- Updated two existing stringify assertions that encoded the old non-standard output (`5/5` → `5-55/5`, `2/2` → `2-30/2`).
- Full suite: `268 passed`. `npm run lint`, `tsc`, and `prettier --check` are clean.