### PR TITLE
fix: CronDate throws on .bind in bundled/CDN builds

### DIFF
--- a/src/CronDate.ts
+++ b/src/CronDate.ts
@@ -14,10 +14,6 @@ export enum DateMathOp {
   Subtract = 'Subtract',
 }
 
-type VerbMap = {
-  [key in TimeUnit]: () => void;
-};
-
 export const DAYS_IN_MONTH: readonly number[] = Object.freeze([31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]);
 
 /**
@@ -28,28 +24,6 @@ export class CronDate {
   #date: DateTime;
   #dstStart: number | null = null;
   #dstEnd: number | null = null;
-
-  /**
-   * Maps the verb to the appropriate method
-   */
-  #verbMap: { add: VerbMap; subtract: VerbMap } = {
-    add: {
-      [TimeUnit.Year]: this.addYear.bind(this),
-      [TimeUnit.Month]: this.addMonth.bind(this),
-      [TimeUnit.Day]: this.addDay.bind(this),
-      [TimeUnit.Hour]: this.addHour.bind(this),
-      [TimeUnit.Minute]: this.addMinute.bind(this),
-      [TimeUnit.Second]: this.addSecond.bind(this),
-    },
-    subtract: {
-      [TimeUnit.Year]: this.subtractYear.bind(this),
-      [TimeUnit.Month]: this.subtractMonth.bind(this),
-      [TimeUnit.Day]: this.subtractDay.bind(this),
-      [TimeUnit.Hour]: this.subtractHour.bind(this),
-      [TimeUnit.Minute]: this.subtractMinute.bind(this),
-      [TimeUnit.Second]: this.subtractSecond.bind(this),
-    },
-  };
 
   /**
    * Constructs a new CronDate instance.
@@ -224,7 +198,20 @@ export class CronDate {
    * @param {TimeUnit} unit
    */
   addUnit(unit: TimeUnit): void {
-    this.#verbMap.add[unit]();
+    switch (unit) {
+      case TimeUnit.Year:
+        return this.addYear();
+      case TimeUnit.Month:
+        return this.addMonth();
+      case TimeUnit.Day:
+        return this.addDay();
+      case TimeUnit.Hour:
+        return this.addHour();
+      case TimeUnit.Minute:
+        return this.addMinute();
+      case TimeUnit.Second:
+        return this.addSecond();
+    }
   }
 
   /**
@@ -232,7 +219,20 @@ export class CronDate {
    * @param {TimeUnit} unit
    */
   subtractUnit(unit: TimeUnit): void {
-    this.#verbMap.subtract[unit]();
+    switch (unit) {
+      case TimeUnit.Year:
+        return this.subtractYear();
+      case TimeUnit.Month:
+        return this.subtractMonth();
+      case TimeUnit.Day:
+        return this.subtractDay();
+      case TimeUnit.Hour:
+        return this.subtractHour();
+      case TimeUnit.Minute:
+        return this.subtractMinute();
+      case TimeUnit.Second:
+        return this.subtractSecond();
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

`CronDate` built its add/subtract dispatch table as a class field initializer using `this.addYear.bind(this)`. jsDelivr's `/+esm` CDN re-bundles through esbuild, which lowers the private fields and runs that initializer before the methods are reachable, so `this.addYear` is `undefined` and `.bind` throws on any parse. Replaced the bound-method map with a `switch` that calls the methods directly.

Fixes #392

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring (no functional changes)

## Testing

- [x] All tests pass (`npm test`) — 275/275
- [x] Code coverage is maintained or improved — `CronDate.ts` stays 100%

## Changes Made

- Removed the `#verbMap` field and the unused `VerbMap` type from `CronDate`.
- `addUnit`/`subtractUnit` now dispatch each `TimeUnit` via a `switch`, calling methods directly.

## Related Issues

- Fixes #392

## Documentation

- [x] Code is self-documenting with clear variable/function names
- [x] Complex logic has helpful comments
- [x] Public API changes are documented with JSDoc — no public API change

## Performance

- [ ] Benchmarks were run before and after changes
- [x] Performance impact is acceptable or improved

Not benchmarked. Removes 12 bound-closure allocations per `CronDate` (constructed on every `next()`/`prev()` step); no behavior change.

## Breaking Changes

None — public API and dispatch behavior are unchanged.

## Code Quality

- [x] Code follows project style guidelines
- [x] ESLint checks pass (`npm run lint`)
- [x] Prettier formatting applied (`npm run format`)
- [x] TypeScript compilation successful (`npm run build`)
- [x] No new TypeScript errors or warnings

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have added tests for my changes — existing suite covers it (build-shape issue)
- [x] All tests pass locally
- [x] My commits have clear, descriptive messages
- [ ] I have rebased my branch on the latest master
