### PR TITLE
fix: do not drop a matching day of month when the day of week uses an nth (#) occurrence

### DIFF
--- a/src/CronExpression.ts
+++ b/src/CronExpression.ts
@@ -217,6 +217,19 @@ export class CronExpression {
   }
 
   /**
+   * Determines if the current date matches the nth occurrence of a weekday in the month.
+   *
+   * @param {number} nthDay - The nth occurrence (1-5) from a `#` expression; values <= 0 mean no nth constraint.
+   * @param {CronDate} currentDate - The current date object.
+   * @returns {boolean} - True if there is no nth constraint, or the current date is the nth occurrence of its weekday; otherwise, false.
+   * @memberof CronExpression
+   * @private
+   */
+  static #isNthWeekdayOfMonthMatch(nthDay: number, currentDate: CronDate): boolean {
+    return nthDay <= 0 || Math.ceil(currentDate.getDate() / 7) === nthDay;
+  }
+
+  /**
    * Find the next scheduled date based on the cron expression.
    * @returns {CronDate} - The next scheduled date or an ES6 compatible iterator object.
    * @memberof CronExpression
@@ -348,13 +361,6 @@ export class CronExpression {
       return false;
     }
 
-    // Check nth day of week if specified
-    if (this.#fields.dayOfWeek.nthDay > 0) {
-      const weekInMonth = Math.ceil(dt.getDate() / 7);
-      if (weekInMonth !== this.#fields.dayOfWeek.nthDay) {
-        return false;
-      }
-    }
     return true;
   }
 
@@ -374,6 +380,7 @@ export class CronExpression {
    * Rule 1: If both "day of month" and "day of week" are restricted (not wildcard), then one or both must match the current day.
    * Rule 2: If "day of month" is restricted and "day of week" is not restricted, then "day of month" must match the current day.
    * Rule 3: If "day of month" is a wildcard, "day of week" is not a wildcard, and "day of week" matches the current day, then the match is accepted.
+   * In all rules, a "day of week" match also honors an nth-occurrence (`#`) constraint (e.g. `5#3` = the 3rd Friday) and the last-weekday (`L`) form.
    * If none of the rules match, the match is rejected.
    *
    * @param {CronDate} currentDate - The current date to be evaluated against the cron expression.
@@ -392,8 +399,10 @@ export class CronExpression {
     const matchedDOM =
       CronExpression.#matchSchedule(currentDate.getDate(), this.#fields.dayOfMonth.values) ||
       (this.#fields.dayOfMonth.hasLastChar && currentDate.isLastDayOfMonth());
+    const nthDay = this.#fields.dayOfWeek.nthDay;
     const matchedDOW =
-      CronExpression.#matchSchedule(currentDate.getDay(), this.#fields.dayOfWeek.values) ||
+      (CronExpression.#matchSchedule(currentDate.getDay(), this.#fields.dayOfWeek.values) &&
+        CronExpression.#isNthWeekdayOfMonthMatch(nthDay, currentDate)) ||
       (this.#fields.dayOfWeek.hasLastChar &&
         CronExpression.#isLastWeekdayOfMonthMatch(this.#fields.dayOfWeek.values, currentDate));
 
@@ -519,12 +528,6 @@ export class CronExpression {
       this.#validateTimeSpan(currentDate);
 
       if (!this.#matchDayOfMonth(currentDate)) {
-        currentDate.applyDateOperation(dateMathVerb, TimeUnit.Day, this.#fields.hour.values.length);
-        continue;
-      }
-      if (
-        !(this.#fields.dayOfWeek.nthDay <= 0 || Math.ceil(currentDate.getDate() / 7) === this.#fields.dayOfWeek.nthDay)
-      ) {
         currentDate.applyDateOperation(dateMathVerb, TimeUnit.Day, this.#fields.hour.values.length);
         continue;
       }

--- a/tests/CronExpression.test.ts
+++ b/tests/CronExpression.test.ts
@@ -611,6 +611,15 @@ describe('CronExpression', () => {
       expect(cronExpression.includesDate(new Date('2023-01-16T00:00:00Z'))).toBeTruthy();
       expect(cronExpression.includesDate(new Date('2023-01-23T00:00:00Z'))).toBeFalsy();
     });
+
+    test('honors day of month when combined with an nth day of week', () => {
+      // Day of month 8 OR the 3rd Friday of the month.
+      const cronExpression = CronExpressionParser.parse('0 0 0 8 * 5#3', { tz: 'UTC' });
+
+      expect(cronExpression.includesDate(new Date('2024-01-08T00:00:00.000Z'))).toBeTruthy();
+      expect(cronExpression.includesDate(new Date('2024-01-19T00:00:00.000Z'))).toBeTruthy();
+      expect(cronExpression.includesDate(new Date('2024-01-12T00:00:00.000Z'))).toBeFalsy();
+    });
   });
 
   describe('DST handling - Europe/Rome (Spring Forward)', () => {

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -651,6 +651,25 @@ describe('CronExpressionParser', () => {
     expect(next.getMonth()).toEqual(7);
   });
 
+  test('day of month combined with nth day of week (OR)', () => {
+    // Day of month 8 OR the 3rd Friday of the month; the two combine with OR.
+    const expectedDates = [
+      '2024-01-08T00:00:00.000Z',
+      '2024-01-19T00:00:00.000Z',
+      '2024-02-08T00:00:00.000Z',
+      '2024-02-16T00:00:00.000Z',
+      '2024-03-08T00:00:00.000Z',
+      '2024-03-15T00:00:00.000Z',
+    ];
+    const interval = CronExpressionParser.parse('0 0 0 8 * 5#3', {
+      currentDate: '2024-01-01T00:00:00.000Z',
+      tz: 'UTC',
+    });
+    for (const expectedDate of expectedDates) {
+      expect(interval.next().toISOString()).toEqual(expectedDate);
+    }
+  });
+
   test('day of month is unspecified', () => {
     // At 02:10:00am, on every Wednesday, every month
     const expectedDates = [


### PR DESCRIPTION
When day-of-month and day-of-week are both restricted they combine with OR. An nth-weekday day-of-week (`#`) was checked by a separate gate over every candidate day, which rejected any day whose week-of-month did not match — including days that only needed to satisfy the day of month.

```
0 0 0 8 * 5#3   // the 8th of the month OR the 3rd Friday
```

From `2024-01-01`, `next()` returned `2024-01-19` (the 3rd Friday) and skipped `2024-01-08`; `includesDate('2024-01-08')` was `false`. Fold the nth constraint into the day-of-week match so an independent day-of-month match is honored.
