### PR TITLE
fix: enforce iteration loop limit so unsatisfiable expressions throw instead of returning a bogus date

### DIFF
--- a/src/CronExpression.ts
+++ b/src/CronExpression.ts
@@ -545,16 +545,20 @@ export class CronExpression {
       }
 
       if (startTimestamp === currentDate.getTime()) {
+        // Still on the start time. Step one second in the search direction and keep
+        // looking so a distinct occurrence is returned. A backwards search that began
+        // on a sub-second offset is the exception: stripping the milliseconds below
+        // already yields an earlier matching time, so break and accept it instead of
+        // spinning until the loop limit.
         if (dateMathVerb === 'Add' || currentDate.getMilliseconds() === 0) {
           currentDate.applyDateOperation(dateMathVerb, TimeUnit.Second, this.#fields.hour.values.length);
+          continue;
         }
-        continue;
       }
       break;
     }
 
-    /* istanbul ignore next - should be impossible under normal use to trigger the branch */
-    if (stepCount > LOOP_LIMIT) {
+    if (stepCount >= LOOP_LIMIT) {
       throw new Error(LOOPS_LIMIT_EXCEEDED_ERROR_MESSAGE);
     }
 

--- a/tests/CronExpression.test.ts
+++ b/tests/CronExpression.test.ts
@@ -293,6 +293,16 @@ describe('CronExpression', () => {
       });
       expect(() => cronExpression.prev()).toThrow(TIME_SPAN_OUT_OF_BOUNDS_ERROR_MESSAGE);
     });
+
+    test('should throw when no occurrence exists within the loop limit', () => {
+      // Day 31 restricted to April and June, which only ever have 30 days, so
+      // the expression can never match and iteration must not return a bogus date.
+      const cronExpression = CronExpressionParser.parse('0 0 0 31 4,6 *', {
+        currentDate: '2024-01-01T00:00:00Z',
+        tz: 'UTC',
+      });
+      expect(() => cronExpression.next()).toThrow(LOOPS_LIMIT_EXCEEDED_ERROR_MESSAGE);
+    });
   });
 
   describe('stringify', () => {


### PR DESCRIPTION
Iterating an unsatisfiable expression returns a date that does not satisfy it instead of throwing. `while (++stepCount < LOOP_LIMIT)` leaves `stepCount` at exactly `LOOP_LIMIT`, but the guard was `if (stepCount > LOOP_LIMIT)`, so it never fired and the loop fell through, returning the current candidate.

```
0 0 0 31 4,6 *   // day 31 in April/June — impossible
```

`next()` returned `2051-05-18` (neither day 31 nor April/June) and `hasNext()` was `true`. Enforce the limit with `>=` so impossible expressions throw; a reverse search that began on a sub-second offset now breaks instead of relying on the dead guard.
