### PR TITLE
fix: reject duplicate 0 in field validation and prevent stringify crash

### DIFF
--- a/src/CronExpressionParser.ts
+++ b/src/CronExpressionParser.ts
@@ -300,9 +300,25 @@ export class CronExpressionParser {
     // used so a redundant alias (`0,7`) collapses to a single value, while a repeated
     // token (`0,0` or `7,7`) is preserved for validate() to reject as a duplicate.
     const sundaySpellings = new Set<number>();
+    // Shared with the array branch below, so a 0/7 alias from a range/step is deduplicated
+    // the same way as an explicit list value.
+    function pushDayOfWeekValue(v: number) {
+      const normalized = v % 7;
+      const redundantAlias = normalized === 0 && stack.includes(0) && !sundaySpellings.has(v);
+      if (normalized === 0) {
+        sundaySpellings.add(v);
+      }
+      if (!redundantAlias) {
+        stack.push(normalized);
+      }
+    }
     function handleResult(result: number | string | (number | string)[], constraints: CronConstraints) {
       if (Array.isArray(result)) {
-        stack.push(...result);
+        if (field === CronUnit.DayOfWeek) {
+          result.forEach((r) => (typeof r === 'number' ? pushDayOfWeekValue(r) : stack.push(r)));
+        } else {
+          stack.push(...result);
+        }
       } else {
         if (CronExpressionParser.#isValidConstraintChar(constraints, result)) {
           stack.push(result);
@@ -318,14 +334,7 @@ export class CronExpressionParser {
             stack.push(result);
             return;
           }
-          const normalized = v % 7;
-          const redundantAlias = normalized === 0 && stack.includes(0) && !sundaySpellings.has(v);
-          if (normalized === 0) {
-            sundaySpellings.add(v);
-          }
-          if (!redundantAlias) {
-            stack.push(normalized);
-          }
+          pushDayOfWeekValue(v);
         }
       }
     }

--- a/src/CronExpressionParser.ts
+++ b/src/CronExpressionParser.ts
@@ -296,6 +296,10 @@ export class CronExpressionParser {
    */
   static #parseSequence(field: CronUnit, val: string, constraints: CronConstraints): (number | string)[] {
     const stack: (number | string)[] = [];
+    // 0 and 7 both denote Sunday in the day-of-week field. Track which spellings were
+    // used so a redundant alias (`0,7`) collapses to a single value, while a repeated
+    // token (`0,0` or `7,7`) is preserved for validate() to reject as a duplicate.
+    const sundaySpellings = new Set<number>();
     function handleResult(result: number | string | (number | string)[], constraints: CronConstraints) {
       if (Array.isArray(result)) {
         stack.push(...result);
@@ -310,7 +314,18 @@ export class CronExpressionParser {
               `Constraint error, got value ${result} expected range ${constraints.min}-${constraints.max}`,
             );
           }
-          stack.push(field === CronUnit.DayOfWeek ? v % 7 : result);
+          if (field !== CronUnit.DayOfWeek) {
+            stack.push(result);
+            return;
+          }
+          const normalized = v % 7;
+          const redundantAlias = normalized === 0 && stack.includes(0) && !sundaySpellings.has(v);
+          if (normalized === 0) {
+            sundaySpellings.add(v);
+          }
+          if (!redundantAlias) {
+            stack.push(normalized);
+          }
         }
       }
     }

--- a/src/CronExpressionParser.ts
+++ b/src/CronExpressionParser.ts
@@ -315,7 +315,8 @@ export class CronExpressionParser {
     function handleResult(result: number | string | (number | string)[], constraints: CronConstraints) {
       if (Array.isArray(result)) {
         if (field === CronUnit.DayOfWeek) {
-          result.forEach((r) => (typeof r === 'number' ? pushDayOfWeekValue(r) : stack.push(r)));
+          // #createRange only ever returns number[] for this field, so `r` is always numeric here.
+          (result as number[]).forEach((r) => pushDayOfWeekValue(r));
         } else {
           stack.push(...result);
         }

--- a/src/fields/CronField.ts
+++ b/src/fields/CronField.ts
@@ -242,8 +242,10 @@ export abstract class CronField {
       );
     }
     // check for duplicate value in this.#values array
+    // NB: find() returns the duplicated value, which can legitimately be 0 (a falsy value),
+    // so the presence check must be explicit rather than relying on truthiness.
     const duplicate = this.#values.find((value, index) => this.#values.indexOf(value) !== index);
-    if (duplicate) {
+    if (duplicate !== undefined) {
       throw new Error(`${this.constructor.name} Validation error, duplicate values found: ${duplicate}`);
     }
   }

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -188,6 +188,75 @@ describe('CronExpressionParser', () => {
     });
   });
 
+  describe('duplicate values', () => {
+    // A duplicated 0 used to slip through the validator (find() returns the value, and 0 is falsy),
+    // so `0,0` was silently accepted while `1,1` was rejected in the same field.
+    test('rejects a duplicated non-zero value in every field', () => {
+      expect(() => CronExpressionParser.parse('1,1 * * * *')).toThrow('duplicate values found: 1');
+      expect(() => CronExpressionParser.parse('* 1,1 * * *')).toThrow('duplicate values found: 1');
+      expect(() => CronExpressionParser.parse('* * 1,1 * *')).toThrow('duplicate values found: 1');
+      expect(() => CronExpressionParser.parse('* * * 1,1 *')).toThrow('duplicate values found: 1');
+      expect(() => CronExpressionParser.parse('* * * * 1,1')).toThrow('duplicate values found: 1');
+    });
+
+    test('rejects a duplicated 0 in every field whose minimum is 0', () => {
+      expect(() => CronExpressionParser.parse('0,0 0 0 1 1 0')).toThrow(
+        'CronSecond Validation error, duplicate values found: 0',
+      );
+      expect(() => CronExpressionParser.parse('0,0 * * * *')).toThrow(
+        'CronMinute Validation error, duplicate values found: 0',
+      );
+      expect(() => CronExpressionParser.parse('0 0,0 * * *')).toThrow(
+        'CronHour Validation error, duplicate values found: 0',
+      );
+      expect(() => CronExpressionParser.parse('0 0 * * 0,0')).toThrow(
+        'CronDayOfWeek Validation error, duplicate values found: 0',
+      );
+      expect(() => CronExpressionParser.parse('0,0,0 * * * *')).toThrow(
+        'CronMinute Validation error, duplicate values found: 0',
+      );
+    });
+
+    test('still accepts valid single and repeated-step values that include 0', () => {
+      expect(() => CronExpressionParser.parse('0 * * * *')).not.toThrow();
+      expect(() => CronExpressionParser.parse('0-5 * * * *')).not.toThrow();
+      expect(() => CronExpressionParser.parse('*/2 * * * *')).not.toThrow();
+      expect(() => CronExpressionParser.parse('0,30 * * * *')).not.toThrow();
+    });
+
+    describe('day of week Sunday alias (0 and 7)', () => {
+      // 0 and 7 both mean Sunday. A redundant alias collapses to a single value,
+      // but a repeated token is a genuine duplicate.
+      test('accepts 0,7 and 7,0 as a single Sunday', () => {
+        expect(CronExpressionParser.parse('0 0 * * 0,7').fields.dayOfWeek.values).toEqual([0]);
+        expect(CronExpressionParser.parse('0 0 * * 7,0').fields.dayOfWeek.values).toEqual([0]);
+      });
+
+      test('rejects a repeated Sunday token 0,0 / 7,7', () => {
+        expect(() => CronExpressionParser.parse('0 0 * * 0,0')).toThrow('duplicate values found: 0');
+        expect(() => CronExpressionParser.parse('0 0 * * 7,7')).toThrow('duplicate values found: 0');
+      });
+
+      test('leaves other day-of-week values and ranges unchanged', () => {
+        expect(CronExpressionParser.parse('0 0 * * 7').fields.dayOfWeek.values).toEqual([0]);
+        expect(CronExpressionParser.parse('0 0 * * 1,7').fields.dayOfWeek.values).toEqual([0, 1]);
+        expect(CronExpressionParser.parse('0 0 * * 0-7').fields.dayOfWeek.values).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+        expect(CronExpressionParser.parse('0 0 * * 5-7').fields.dayOfWeek.values).toEqual([0, 5, 6, 7]);
+        expect(() => CronExpressionParser.parse('0 0 * * 1,1')).toThrow('duplicate values found: 1');
+      });
+    });
+
+    test('stringify() no longer crashes on a parsed expression (Unexpected range step)', () => {
+      // A duplicated 0 previously produced a step of 0 that tripped an "unreachable" invariant.
+      // These now fail validation at parse time, so stringify() is never reached with a bad field.
+      expect(() => CronExpressionParser.parse('0,0,0 * * * *')).toThrow();
+      expect(() => CronExpressionParser.parse('0 0 * * 0,0,0')).toThrow();
+      // Valid expressions still round-trip cleanly through stringify().
+      expect(CronExpressionParser.parse('0 0 * * 0,7').stringify()).toEqual('0 0 * * 0');
+      expect(CronExpressionParser.parse('*/15 0 * * *').stringify()).toEqual('*/15 0 * * *');
+    });
+  });
+
   describe('take multiple dates', () => {
     test('step', () => {
       const options = {

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -240,9 +240,16 @@ describe('CronExpressionParser', () => {
       test('leaves other day-of-week values and ranges unchanged', () => {
         expect(CronExpressionParser.parse('0 0 * * 7').fields.dayOfWeek.values).toEqual([0]);
         expect(CronExpressionParser.parse('0 0 * * 1,7').fields.dayOfWeek.values).toEqual([0, 1]);
-        expect(CronExpressionParser.parse('0 0 * * 0-7').fields.dayOfWeek.values).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
-        expect(CronExpressionParser.parse('0 0 * * 5-7').fields.dayOfWeek.values).toEqual([0, 5, 6, 7]);
+        // The range's own trailing 7 is now a redundant alias of the 0 the same range
+        // already produced, so it collapses just like an explicit `0,7` would.
+        expect(CronExpressionParser.parse('0 0 * * 0-7').fields.dayOfWeek.values).toEqual([0, 1, 2, 3, 4, 5, 6]);
+        expect(CronExpressionParser.parse('0 0 * * 5-7').fields.dayOfWeek.values).toEqual([0, 5, 6]);
         expect(() => CronExpressionParser.parse('0 0 * * 1,1')).toThrow('duplicate values found: 1');
+      });
+
+      test('rejects the alias regardless of which atom (scalar or range) comes first', () => {
+        expect(() => CronExpressionParser.parse('0 0 * * 0-7,0')).toThrow('duplicate values found: 0');
+        expect(() => CronExpressionParser.parse('0 0 * * 7,0-7')).toThrow('duplicate values found: 0');
       });
     });
 

--- a/tests/CronField.test.ts
+++ b/tests/CronField.test.ts
@@ -1,4 +1,4 @@
-import { CronDayOfWeek, CronField, CronSecond, DayOfWeekRange, SixtyRange } from '../src';
+import { CronDayOfWeek, CronField, CronHour, CronMinute, CronSecond, DayOfWeekRange, SixtyRange } from '../src';
 
 describe('CronField', () => {
   describe('wildcard detection', () => {
@@ -60,6 +60,23 @@ describe('CronField', () => {
       const values: (number | string)[] = ['5L'];
       const field = new CronDayOfWeek(values as DayOfWeekRange[]);
       expect(field.values).toEqual(['5L']);
+    });
+
+    test('should throw an error when the duplicated value is 0 (falsy)', () => {
+      // find() returns the duplicated value; a duplicated 0 must not be treated as "no duplicate".
+      expect(() => new CronSecond([0, 0])).toThrow('CronSecond Validation error, duplicate values found: 0');
+      expect(() => new CronMinute([0, 0])).toThrow('CronMinute Validation error, duplicate values found: 0');
+      expect(() => new CronHour([0, 0])).toThrow('CronHour Validation error, duplicate values found: 0');
+      expect(() => new CronDayOfWeek([0, 0])).toThrow('CronDayOfWeek Validation error, duplicate values found: 0');
+      expect(() => new CronSecond([0, 0, 0])).toThrow('CronSecond Validation error, duplicate values found: 0');
+    });
+
+    test('should not reject a non-duplicate set that contains 0', () => {
+      expect(() => new CronSecond([0, 1])).not.toThrow();
+      expect(() => new CronMinute([0, 30])).not.toThrow();
+      // CronField.validate() checks raw values, not day-of-week aliasing (that lives in the
+      // parser); 0 and 7 are distinct raw values so the class itself accepts both.
+      expect(new CronDayOfWeek([0, 7]).values).toEqual([0, 7]);
     });
   });
 


### PR DESCRIPTION
### Problem

`CronField.validate()` checks for duplicate field values with:

```ts
const duplicate = this.#values.find((value, index) => this.#values.indexOf(value) !== index);
if (duplicate) {
  throw new Error(`... duplicate values found: ${duplicate}`);
}
```

`Array.prototype.find` returns the duplicated **value**, so when that value is `0`, `if (duplicate)` evaluates `if (0)` and the check is skipped. The validator therefore rejects `1,1` but silently accepts `0,0` in the same field. It affects every field whose minimum is `0` (second, minute, hour, dayOfWeek); `dayOfMonth`/`month` start at 1 and are unaffected.

Two observable failures:

1. **Self-inconsistent validation** — `1,1` is rejected everywhere, but `0,0` is accepted.
2. **Public `stringify()` crash** — an accepted duplicate `0` yields a range step of `0`, which trips the internal `/* istanbul ignore */` invariant `Unexpected range step`. A branch marked unreachable is reachable from public input:

```js
CronExpressionParser.parse('0,0,0 * * * *').stringify(); // throws "Unexpected range step"
CronExpressionParser.parse('0 0 * * 0,0,0').stringify();  // throws
```

The field classes are part of the public API (`new CronMinute([0, 0])`), so the same acceptance and crash are reachable via direct construction, not only the parser.

### Fix

- `CronField.validate()`: use an explicit `duplicate !== undefined` check (`find` returns `undefined` when there is no duplicate). This restores duplicate rejection for `0` and, by preventing the bad field from being constructed, removes the `stringify()` crash at its source for both the parser and direct-construction paths.
- **Day-of-week `0`/`7`:** `0` and `7` both mean Sunday, so `0,7` reaches the validator as `[0, 0]` after the existing `% 7` normalization. To avoid newly rejecting a valid `0,7`, the parser now collapses that redundant alias to a single Sunday, while a repeated *token* (`0,0`, `7,7`) is preserved so it is still rejected as a duplicate. This matches the existing treatment of Sunday's dual encoding (#295) and the `new CronDayOfWeek([0, 7])` case already exercised in the tests.

Resulting day-of-week behaviour: `0,7` / `7,0` → accepted as Sunday; `0,0` / `7,7` / `1,1` → rejected; bare `7`, `1,7`, ranges and `*` are unchanged.

### Tests

Added coverage in `tests/CronField.test.ts` (direct construction) and `tests/CronExpressionParser.test.ts` (parse + stringify round-trip): duplicate-`0` rejection across all four affected fields, the accept/reject matrix for the day-of-week `0`/`7` alias, valid inputs that contain `0`, and a stringify no-crash regression. Full suite: 289 passing (`TZ=UTC npx jest`); `tsc`, ESLint and Prettier clean.
