### PR TITLE
fix: escape hyphen in #parseNthDay character class

### DIFF
--- a/src/CronExpressionParser.ts
+++ b/src/CronExpressionParser.ts
@@ -441,7 +441,7 @@ export class CronExpressionParser {
       return { dayOfWeek: atoms[0] };
     }
     const nthValue = +atoms[atoms.length - 1];
-    const matches = val.match(/([,-/])/);
+    const matches = val.match(/([,\-/])/);
     if (matches !== null) {
       throw new Error(
         `Constraint error, invalid dayOfWeek \`#\` and \`${matches?.[0]}\` special characters are incompatible`,

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -159,6 +159,11 @@ describe('CronExpressionParser', () => {
       );
     });
 
+    test('invalid characters test - dot', () => {
+      const expression = '0 0 0 ? * 1.2#2';
+      expect(() => CronExpressionParser.parse(expression)).toThrow('Invalid characters, got value: 1.2');
+    });
+
     test('invalid occurrence value', () => {
       const expressions = ['0 0 0 ? * 1#', '0 0 0 ? * 1#0', '0 0 0 ? * 4#6', '0 0 0 ? * 0##4'];
       for (const expression of expressions) {


### PR DESCRIPTION
## Description

`[,-/]` in `#parseNthDay` is a character range spanning `0x2C`-`0x2F`, so it also
matches `.`. The guard is meant to reject `,`, `-` and `/` combined with `#`.

Escaping the hyphen matches the three characters literally. `1.2#2` is invalid
either way, so the only change is which error surfaces:

```
before: Constraint error, invalid dayOfWeek `#` and `.` special characters are incompatible
after:  Invalid characters, got value: 1.2
```

Fixes #421

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] All tests pass (`npm test`)
- [x] Code coverage is maintained or improved

## Changes Made

- `src/CronExpressionParser.ts`: escape the hyphen in the `#parseNthDay` character class
- `tests/CronExpressionParser.test.ts`: assert `1.2#2` reports invalid characters

## Related Issues

- Fixes #421

## Code Quality

- [x] Code follows project style guidelines
- [x] ESLint checks pass (`npm run lint`)
- [x] Prettier formatting applied (`npm run format`)
- [x] TypeScript compilation successful (`npm run build`)
