### PR TITLE
fix: reject standalone L in day of week at construction

### DIFF
--- a/src/CronExpression.ts
+++ b/src/CronExpression.ts
@@ -203,17 +203,12 @@ export class CronExpression {
    * @private
    */
   static #isLastWeekdayOfMonthMatch(expressions: (number | string)[], currentDate: CronDate): boolean {
-    const isLastWeekdayOfMonth = currentDate.isLastWeekdayOfMonth();
-    return expressions.some((expression: number | string) => {
-      // The first character represents the weekday
-      const weekday = parseInt(expression.toString().charAt(0), 10) % 7;
-      if (Number.isNaN(weekday)) {
-        throw new Error(`Invalid last weekday of the month expression: ${expression}`);
-      }
+    if (!currentDate.isLastWeekdayOfMonth()) {
+      return false;
+    }
 
-      // Check if the current date matches the last specified weekday of the month
-      return currentDate.getDay() === weekday && isLastWeekdayOfMonth;
-    });
+    const day = currentDate.getDay();
+    return expressions.some((expression) => day === parseInt(expression.toString().charAt(0), 10) % 7);
   }
 
   /**

--- a/src/fields/CronDayOfWeek.ts
+++ b/src/fields/CronDayOfWeek.ts
@@ -35,6 +35,9 @@ export class CronDayOfWeek extends CronField {
   constructor(values: DayOfWeekRange[], options?: CronFieldOptions) {
     super(values, options);
     this.validate();
+    if (this.values.some((value) => value === 'L')) {
+      throw new Error(`${this.constructor.name} Validation error, unexpected standalone L`);
+    }
   }
 
   /**

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -1784,11 +1784,16 @@ describe('CronExpressionParser', () => {
       expect(interval.next().getDate()).toBe(27);
     });
 
-    test('throw new Errors to parse for invalid last weekday of month expression', () => {
-      expect(() => {
-        const interval = CronExpressionParser.parse('0 0 0 * * L');
-        interval.next();
-      }).toThrow();
+    test('throws when parsing a standalone last weekday of the month marker', () => {
+      expect(() => CronExpressionParser.parse('0 0 0 * * L')).toThrow(
+        'CronDayOfWeek Validation error, unexpected standalone L',
+      );
+    });
+
+    test('throws when parsing a standalone last weekday of the month marker in a list', () => {
+      expect(() => CronExpressionParser.parse('0 0 0 * * 1,L')).toThrow(
+        'CronDayOfWeek Validation error, unexpected standalone L',
+      );
     });
   });
 

--- a/tests/CronField.test.ts
+++ b/tests/CronField.test.ts
@@ -1,4 +1,4 @@
-import { CronDayOfWeek, CronField, CronSecond, SixtyRange } from '../src';
+import { CronDayOfWeek, CronField, CronSecond, DayOfWeekRange, SixtyRange } from '../src';
 
 describe('CronField', () => {
   describe('wildcard detection', () => {
@@ -46,6 +46,20 @@ describe('CronField', () => {
       const field = new CronSecond(values);
       values.push(30);
       expect(field.values).toEqual([10, 20]);
+    });
+
+    test('should throw an error when day of week is a standalone L', () => {
+      expect(() => new CronDayOfWeek(['L'])).toThrow('CronDayOfWeek Validation error, unexpected standalone L');
+    });
+
+    test('should throw an error when day of week contains a standalone L in a list', () => {
+      expect(() => new CronDayOfWeek([1, 'L'])).toThrow('CronDayOfWeek Validation error, unexpected standalone L');
+    });
+
+    test('should accept a day of week L qualified by a weekday', () => {
+      const values: (number | string)[] = ['5L'];
+      const field = new CronDayOfWeek(values as DayOfWeekRange[]);
+      expect(field.values).toEqual(['5L']);
     });
   });
 

--- a/tests/CronFieldCollection.test.ts
+++ b/tests/CronFieldCollection.test.ts
@@ -350,15 +350,22 @@ describe('CronFieldCollection', () => {
     });
 
     test('should handle special characters (L)', () => {
+      const dayOfWeek: (number | string)[] = ['5L'];
       const result = CronFieldCollection.from(base, {
         dayOfMonth: ['L'],
-        dayOfWeek: ['L'],
+        dayOfWeek: dayOfWeek as DayOfWeekRange[],
       });
       expect(result.dayOfMonth).not.toBe(base.dayOfMonth);
       expect(result.dayOfMonth.values).toEqual(['L']);
       expect(result.dayOfWeek).not.toBe(base.dayOfWeek);
-      expect(result.dayOfWeek.values).toEqual(['L']);
-      expect(result.stringify(true)).toEqual('0 0 12 L 1 L');
+      expect(result.dayOfWeek.values).toEqual(['5L']);
+      expect(result.stringify(true)).toEqual('0 0 12 L 1 5L');
+    });
+
+    test('should throw when day of week is a standalone L', () => {
+      expect(() => CronFieldCollection.from(base, { dayOfWeek: ['L'] })).toThrow(
+        'CronDayOfWeek Validation error, unexpected standalone L',
+      );
     });
 
     test('should handle mix of CronField instances and raw values', () => {


### PR DESCRIPTION
## Description

A standalone `L` in the day-of-week field passes validation and only fails once iteration
reaches a candidate date, so `parse()` accepts an expression that can never be scheduled:

```js
const expr = CronExpressionParser.parse('0 0 * * L');   // ok
expr.next();
// Error: Invalid last weekday of the month expression: L
```

`CronField.validate()` tests characters with `^\d{0,2}L$`, and `{0,2}` also admits the
zero-digit form. It applies inside a list too (`L,1`, `1,L`).

Rejecting it in the `CronDayOfWeek` constructor puts the error at the validation boundary and
covers the `CronFieldCollection.from()` route, which could otherwise build a collection that
stringifies to `0 0 12 L 1 L` and throws on the first `next()`. Every affected expression
already threw, so only the timing and the message change:

```
before: parse() ok, next() -> Invalid last weekday of the month expression: L
after:  parse()        -> CronDayOfWeek Validation error, unexpected standalone L
```

Quartz and AWS EventBridge do give a bare `L` a meaning in day-of-week, but define it as
`7`/`SAT` under 1-7 SUN-SAT numbering, which doesn't carry over to 0-7 with 0 and 7 both
Sunday. Spring, croner and node-cron all require the qualified form.

Fixes #422

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] All tests pass (`npm test`)
- [x] Code coverage is maintained or improved

## Changes Made

- `src/fields/CronDayOfWeek.ts`: reject a standalone `L` at construction
- `src/CronExpression.ts`: drop the now-unreachable `NaN` guard in `#isLastWeekdayOfMonthMatch`
  (every remaining value is a number or `^\d{1,2}L$`) and return early when the date isn't the
  last weekday of its month
- `tests/`: assert the throw happens at parse time, bare and in a list, and that `5L` still works

## Related Issues

- Fixes #422
- Related to #257: the Quartz sentence it quotes covers both day fields, and this delivers it
  for day-of-week — a list containing a bare `L` is now rejected. Day-of-month is untouched,
  where `L` is a value in its own right and `2,3,L` yields the 2nd, 3rd and last day.

## Performance

Parse costs ~1% for the extra scan over the day-of-week values (13.5 -> 13.7 µs); `next()` is
unchanged.

- [x] Benchmarks were run before and after changes
- [x] Performance impact is acceptable or improved

## Code Quality

- [x] Code follows project style guidelines
- [x] ESLint checks pass (`npm run lint`)
- [x] Prettier formatting applied (`npm run format`)
- [x] TypeScript compilation successful (`npm run build`)

