### PR TITLE
chore: report coverage and benchmark on every PR commit

### DIFF
--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -14,6 +14,9 @@ on:
 
 permissions:
   contents: read
+  # Required by download-artifact to read the producer's run. Declaring `permissions` at all
+  # sets every unlisted scope to `none`, so omitting this makes the download 403.
+  actions: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/pr-quality-comment.yml
+++ b/.github/workflows/pr-quality-comment.yml
@@ -1,0 +1,78 @@
+name: PR Quality Gates Comment
+
+# Posts the results collected by the PR Quality Gates workflow back to the pull request.
+#
+# This runs separately because a fork's GITHUB_TOKEN is read-only on `pull_request`, so the
+# producer cannot comment. `workflow_run` runs from the default branch with a write token --
+# and therefore must never check out, build or execute pull request code. Its only input is
+# the data artifact. Using `pull_request_target` instead would hand a write token to fork code.
+
+on:
+  workflow_run:
+    workflows: ['PR Quality Gates']
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - name: Download results
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-quality
+          path: pr-quality
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Render comment
+        run: node scripts/render-pr-quality-comment.mjs pr-quality > comment.md
+
+      - name: Upsert comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('node:fs');
+
+            const marker = '<!-- pr-quality-gates -->';
+            const body = fs.readFileSync('comment.md', 'utf8');
+            const issueNumber = Number(fs.readFileSync('pr-quality/pr-number.txt', 'utf8').trim());
+
+            if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+              core.setFailed('Artifact did not contain a usable pull request number');
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => comment.user.type === 'Bot' && comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
+              core.info(`Updated comment ${existing.id} on #${issueNumber}`);
+            } else {
+              const created = await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issueNumber,
+                body,
+              });
+              core.info(`Created comment ${created.data.id} on #${issueNumber}`);
+            }

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,0 +1,48 @@
+name: PR Quality Gates
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-quality-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run coverage
+        run: npm run test:coverage
+
+      - name: Run benchmark
+        run: npm run bench
+
+      - name: Collect results
+        run: |
+          mkdir -p pr-quality
+          cp coverage/coverage-summary.json pr-quality/
+          cp benchmarks/results/benchmark-results.json pr-quality/
+          echo "${{ github.event.pull_request.number }}" > pr-quality/pr-number.txt
+          echo "${{ github.event.pull_request.head.sha }}" > pr-quality/head-sha.txt
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-quality
+          path: pr-quality/
+          retention-days: 7

--- a/benchmarks/index.ts
+++ b/benchmarks/index.ts
@@ -1,4 +1,4 @@
-import { initializeBenchmark, parseAndBenchMarkExpression, printSummary } from './runner';
+import { benchmarkResults, initializeBenchmark, parseAndBenchMarkExpression, printSummary } from './runner';
 import { benchmarkInputs } from './benchmark-inputs';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -8,7 +8,7 @@ async function runBenchmarks() {
   const iterations = process.env.BENCHMARK_ITERATIONS ? parseInt(process.env.BENCHMARK_ITERATIONS, 10) : 10000;
   const samples = process.env.BENCHMARK_SAMPLES ? parseInt(process.env.BENCHMARK_SAMPLES, 10) : 5;
 
-  await initializeBenchmark(version);
+  const baselineVersion = await initializeBenchmark(version);
 
   // Create results directory
   const resultsDir = path.join(__dirname, 'results');
@@ -22,7 +22,7 @@ async function runBenchmarks() {
   // Write header to results file
   const header = `Benchmark Results
 Timestamp: ${new Date().toISOString()}
-Package Version: ${version || 'latest'}
+Package Version: ${baselineVersion}
 ${'-'.repeat(50)}\n\n`;
 
   fs.writeFileSync(outputFile, header);
@@ -39,6 +39,14 @@ ${'-'.repeat(50)}\n\n`;
   }
 
   printSummary();
+
+  const jsonOutputFile = path.join(resultsDir, 'benchmark-results.json');
+  fs.writeFileSync(
+    jsonOutputFile,
+    JSON.stringify({ baselineVersion, iterations, samples, results: benchmarkResults }, null, 2),
+  );
+
+  console.log(`\nResults written to:\n  ${outputFile}\n  ${jsonOutputFile}`);
 }
 
 runBenchmarks().catch(console.error);

--- a/benchmarks/runner.ts
+++ b/benchmarks/runner.ts
@@ -23,12 +23,14 @@ type ParseExpressionFn = (
 let oldParseExpression: ParseExpressionFn;
 const newParseExpression = CronExpressionParser.parse as ParseExpressionFn;
 
-export async function initializeBenchmark(version?: string) {
+export async function initializeBenchmark(version?: string): Promise<string> {
   const { version: resolvedVersion, packagePath } = await VersionManager.getPackageVersion(version);
   console.log(`Using cron-parser version ${resolvedVersion} for comparison`);
 
   const module = require(packagePath);
   oldParseExpression = (module.default?.parse as ParseExpressionFn) ?? (module.parseExpression as ParseExpressionFn);
+
+  return resolvedVersion;
 }
 
 interface BenchmarkStats {

--- a/scripts/render-pr-quality-comment.mjs
+++ b/scripts/render-pr-quality-comment.mjs
@@ -30,6 +30,23 @@ const coverage = JSON.parse(readArtifact('coverage-summary.json'));
 const benchmark = JSON.parse(readArtifact('benchmark-results.json'));
 const headSha = readArtifact('head-sha.txt').trim();
 
+// Both JSON files are produced by code running from the pull request -- benchmark-inputs.ts,
+// benchmarks/index.ts and jest.config.js are all fork-modifiable -- so every value read out of
+// them is untrusted. Nothing here is executed, but interpolating a raw string into the comment
+// would let a fork break out of a code span or table cell and post arbitrary markdown under the
+// github-actions[bot] identity. Sanitize on the way in and bound the output size.
+
+const MAX_FIELD_LENGTH = 120;
+const MAX_ROWS = 100;
+
+const clean = (value, maxLength = MAX_FIELD_LENGTH) =>
+  String(value)
+    .replace(/[`|<>\r\n]/g, ' ')
+    .trim()
+    .slice(0, maxLength);
+
+const number = (value) => (Number.isFinite(Number(value)) ? Number(value) : 0);
+
 const pct = (metric) => {
   const value = coverage.total?.[metric]?.pct;
   if (typeof value !== 'number') {
@@ -38,16 +55,20 @@ const pct = (metric) => {
   return `${value}%`;
 };
 
-const ms = (value) => `${value.toFixed(2)}ms`;
-const signed = (value) => `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+const ms = (value) => `${number(value).toFixed(2)}ms`;
+const signed = (value) => `${number(value) >= 0 ? '+' : ''}${number(value).toFixed(2)}%`;
 
 const benchmarkRow = (result) =>
-  `| \`${result.pattern}\` | ${ms(result.oldMean)} | ${ms(result.newMean)} | ${signed(result.change)} |`;
+  `| \`${clean(result.pattern)}\` | ${ms(result.oldMean)} | ${ms(result.newMean)} | ${signed(result.change)} |`;
 
-const benchmarkRows = benchmark.results.map(benchmarkRow).join('\n');
+const results = Array.isArray(benchmark.results) ? benchmark.results : [];
+const shownResults = results.slice(0, MAX_ROWS);
+const benchmarkRows = shownResults.map(benchmarkRow).join('\n');
+const truncatedNote =
+  results.length > shownResults.length ? `\n\n_Showing the first ${MAX_ROWS} of ${results.length} patterns._` : '';
 
 process.stdout.write(`${MARKER}
-## Quality gates · commit \`${headSha.slice(0, 7)}\`
+## Quality gates · commit \`${clean(headSha, 7)}\`
 
 ### Coverage
 
@@ -55,13 +76,13 @@ process.stdout.write(`${MARKER}
 |---|---|---|---|
 | ${pct('statements')} | ${pct('branches')} | ${pct('functions')} | ${pct('lines')} |
 
-### Benchmark — vs \`cron-parser@${benchmark.baselineVersion}\` (npm latest)
+### Benchmark — vs \`cron-parser@${clean(benchmark.baselineVersion, 40)}\` (npm latest)
 
-${benchmark.iterations} iterations × ${benchmark.samples} ${benchmark.samples === 1 ? 'sample' : 'samples'} per pattern. A positive change is faster than the baseline.
+${number(benchmark.iterations)} iterations × ${number(benchmark.samples)} ${number(benchmark.samples) === 1 ? 'sample' : 'samples'} per pattern. A positive change is faster than the baseline.
 
 | Pattern | Baseline | This PR | Change |
 |---|---|---|---|
-${benchmarkRows}
+${benchmarkRows}${truncatedNote}
 
 <sub>Informational only. Runner timings are noisy and this check never fails.</sub>
 `);

--- a/scripts/render-pr-quality-comment.mjs
+++ b/scripts/render-pr-quality-comment.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+/**
+ * Renders the sticky pull request quality-gates comment from the artifact uploaded by the
+ * PR Quality Gates workflow. Takes the artifact directory (default: pr-quality) and writes
+ * markdown to stdout. Run by the PR Quality Gates Comment workflow, which pipes the output
+ * to a file and posts it.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const MARKER = '<!-- pr-quality-gates -->';
+const ARTIFACT_DIR = resolve(process.argv[2] ?? 'pr-quality');
+
+const fail = (message) => {
+  console.error(message);
+  process.exit(1);
+};
+
+const readArtifact = (name) => {
+  try {
+    return readFileSync(join(ARTIFACT_DIR, name), 'utf8');
+  } catch {
+    return fail(`Unable to read ${join(ARTIFACT_DIR, name)}`);
+  }
+};
+
+const coverage = JSON.parse(readArtifact('coverage-summary.json'));
+const benchmark = JSON.parse(readArtifact('benchmark-results.json'));
+const headSha = readArtifact('head-sha.txt').trim();
+
+const pct = (metric) => {
+  const value = coverage.total?.[metric]?.pct;
+  if (typeof value !== 'number') {
+    fail(`Coverage summary is missing total.${metric}.pct`);
+  }
+  return `${value}%`;
+};
+
+const ms = (value) => `${value.toFixed(2)}ms`;
+const signed = (value) => `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+
+const benchmarkRow = (result) =>
+  `| \`${result.pattern}\` | ${ms(result.oldMean)} | ${ms(result.newMean)} | ${signed(result.change)} |`;
+
+const benchmarkRows = benchmark.results.map(benchmarkRow).join('\n');
+
+process.stdout.write(`${MARKER}
+## Quality gates · commit \`${headSha.slice(0, 7)}\`
+
+### Coverage
+
+| Statements | Branches | Functions | Lines |
+|---|---|---|---|
+| ${pct('statements')} | ${pct('branches')} | ${pct('functions')} | ${pct('lines')} |
+
+### Benchmark — vs \`cron-parser@${benchmark.baselineVersion}\` (npm latest)
+
+${benchmark.iterations} iterations × ${benchmark.samples} ${benchmark.samples === 1 ? 'sample' : 'samples'} per pattern. A positive change is faster than the baseline.
+
+| Pattern | Baseline | This PR | Change |
+|---|---|---|---|
+${benchmarkRows}
+
+<sub>Informational only. Runner timings are noisy and this check never fails.</sub>
+`);


### PR DESCRIPTION
## Description

Adds two PR-only quality gates that report back as a single sticky comment, edited in place on every commit. Neither blocks — correctness gating stays in `push.yml`, untouched.

- **Coverage** — current numbers for the PR head
- **Benchmark** — PR head vs the latest published release, the baseline `npm run bench` already uses

Split across two workflows because most PRs here come from forks, where `pull_request` gets a read-only token and cannot comment. `pr-quality.yml` measures and uploads an artifact using the default read-only token; `pr-quality-comment.yml` runs on `workflow_run` from master with `pull-requests: write` and only ever reads that artifact — it never checks out or executes PR code. `pull_request_target` would have handed a write token to fork code.

## Type of Change

- [x] Build/CI/tooling changes

## Testing

- [x] All tests pass (`npm test`)
- [x] Code coverage is maintained or improved

## Changes Made

- `pr-quality.yml` — runs coverage and the benchmark on every PR commit, uploads a `pr-quality` artifact. Read-only token, single Node version, `cancel-in-progress` so a slow run can't overwrite a newer commit's numbers.
- `pr-quality-comment.yml` — `workflow_run` consumer that renders the artifact and upserts one marker-identified comment. Needs `actions: read` to read the producer's run.
- `scripts/render-pr-quality-comment.mjs` — artifact directory to markdown. Kept out of the YAML because `actions/github-script` runs CommonJS and can't `require` an `.mjs`.
- `benchmarks/` — `npm run bench` now also writes a stable-named `benchmark-results.json`, and its `.txt` header records the resolved baseline version instead of the literal `latest`.

## Code Quality

- [x] Code follows project style guidelines
- [x] ESLint checks pass (`npm run lint`)
- [x] Prettier formatting applied (`npm run format`)
- [x] TypeScript compilation successful (`npm run build`)

## Additional Notes

`workflow_run` workflows only fire from the default branch, so the comment cannot run on this PR — and it didn't. The `PR Quality Gates` job passed and uploaded a `pr-quality` artifact, which is everything this PR can verify before merge. Confirming the comment itself needs a throwaway PR after merge.
