### PR TITLE
docs: document benchmark environment variables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,6 +260,9 @@ PACKAGE_VERSION=5.6.2 npm run bench
 BENCHMARK_ITERATIONS=100 BENCHMARK_SAMPLES=1 npm run bench
 ```
 
+Each run writes a timestamped `.txt` report and a `benchmark-results.json` summary to
+`benchmarks/results/`, which is gitignored.
+
 When making performance-related changes:
 
 1. **Run benchmarks before** your changes to establish baseline

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,6 +250,16 @@ npm run bench:pattern
 npm run bench:clean
 ```
 
+The run can be tuned with environment variables:
+
+```bash
+# Compare against a specific published version instead of the latest release
+PACKAGE_VERSION=5.6.2 npm run bench
+
+# Shorten a run while iterating (defaults: 10000 iterations, 5 samples)
+BENCHMARK_ITERATIONS=100 BENCHMARK_SAMPLES=1 npm run bench
+```
+
 When making performance-related changes:
 
 1. **Run benchmarks before** your changes to establish baseline


### PR DESCRIPTION
Documents the three environment variables `benchmarks/index.ts` already reads (`PACKAGE_VERSION`, `BENCHMARK_ITERATIONS`, `BENCHMARK_SAMPLES`), none of which appear in any documentation today.

Also serves as the first PR exercising the quality gates merged in #430 — the sticky comment cannot run on its own introducing PR, so this is the first chance to see it fire.