### PR TITLE
docs: add security policy and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+For this project, community spaces include the [issue tracker](https://github.com/harrisiirak/cron-parser/issues), pull requests, [discussions](https://github.com/harrisiirak/cron-parser/discussions), and commit and review comments.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by:
+
+- Reporting the account, comment, or content directly to GitHub via [Report abuse](https://github.com/contact/report-abuse) - this is the fastest route for harassment, spam, or anything that violates GitHub's own policies, and GitHub can act on accounts in ways that project maintainers cannot
+- Contacting the maintainer privately through the contact details on their [GitHub profile](https://github.com/harrisiirak), if you would like the project itself to respond
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thank you for your interest in contributing to cron-parser! This document provid
 ## Table of Contents
 
 - [Code of Conduct](#code-of-conduct)
+- [Reporting Security Issues](#reporting-security-issues)
 - [Getting Started](#getting-started)
 - [Development Setup](#development-setup)
 - [How to Contribute](#how-to-contribute)
@@ -17,7 +18,11 @@ Thank you for your interest in contributing to cron-parser! This document provid
 
 ## Code of Conduct
 
-This project and everyone participating in it are governed by a commitment to creating a welcoming and inclusive environment. Please be respectful in all interactions.
+This project and everyone participating in it are governed by the [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold it. Please report unacceptable behavior using the channels listed there.
+
+## Reporting Security Issues
+
+Do not open a public issue or pull request for a security vulnerability. Report it privately following the [Security Policy](SECURITY.md).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -403,6 +403,12 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 - Pull request process
 - Reporting bugs and requesting features
 
+Participation is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Security
+
+To report a security vulnerability, please follow the [Security Policy](SECURITY.md) rather than opening a public issue.
+
 ## License
 
 MIT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are released for the `5.x` line only. Older majors are end-of-life and will not receive patches; please upgrade before reporting an issue against them.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.x     | :white_check_mark: |
+| 4.x     | :x:                |
+| < 4.0   | :x:                |
+
+Fixes land on the latest `5.x` release. There are no long-term support branches for earlier minors, so the remedy for any advisory is to upgrade to the newest `5.x` version.
+
+## Reporting a Vulnerability
+
+**Please do not report security issues through public GitHub issues, pull requests or discussions.**
+
+Report privately through GitHub Security Advisories: open [Report a vulnerability](https://github.com/harrisiirak/cron-parser/security/advisories/new), or go to the repository's **Security** tab and click **Report a vulnerability**. This creates a private thread visible only to you and the maintainers.
+
+Please include as much of the following as you can:
+
+- The cron expression, crontab file content, or API call that triggers the issue
+- A minimal reproduction (a short script is ideal) and the observed behaviour
+- The version of cron-parser and Node.js you tested against
+- Your assessment of the impact, and any suggested fix or mitigation
+
+## What to Expect
+
+cron-parser is maintained by volunteers, so response times are best-effort rather than contractual:
+
+- **Acknowledgement** - receipt is confirmed within 5 business days
+- **Assessment** - the report is confirmed or dismissed, with reasoning, within 14 days
+- **Fix** - confirmed issues are patched and released as soon as practical, prioritised by severity
+- **Updates** - the advisory thread is kept up to date while the report is open
+
+If you have not heard back within 14 days, feel free to post a nudge in the advisory thread.
+
+## Disclosure Policy
+
+This project follows coordinated disclosure. Please allow a reasonable window for a fix to ship before disclosing publicly. Once a patched release is available, a GitHub Security Advisory is published (requesting a CVE where warranted) and the reporter is credited by name unless anonymity is requested.
+
+## Scope
+
+cron-parser is a pure parsing and date-calculation library. It parses cron expressions and computes matching dates. It never executes commands, spawns processes, opens network connections, or acts as a scheduler. The security-relevant surface is therefore what happens when it is handed untrusted input.
+
+**In scope:**
+
+- A crafted cron expression that causes a hang, unbounded loop, unbounded memory growth, or a non-`Error` crash in `CronExpressionParser.parse()`
+- Catastrophic backtracking (ReDoS) in expression validation
+- Prototype pollution or similar object-integrity issues via parsed field values or crontab variable names
+- Path handling or resource-exhaustion issues in `CronFileParser.parseFile()` / `parseFileSync()` when pointed at a crafted crontab file
+- Any way to make the library reach outside its documented behaviour (executing, reading, or writing something it should not)
+
+**Out of scope:**
+
+- Vulnerabilities in dependencies such as [luxon](https://github.com/moment/luxon) - report those upstream, though please do open an advisory here if cron-parser needs to ship a version bump
+- Incorrect schedules, wrong DST handling, or other correctness bugs with no security impact - these are normal [bug reports](https://github.com/harrisiirak/cron-parser/issues/new?template=bug_report.md)
+- Slow iteration over expressions you control that are valid but expensive (for example stepping across many years) - see the hardening notes below
+- Anything that requires the attacker to already control the host process or its dependencies
+
+## Hardening Notes for Users
+
+If you accept cron expressions from your users, treat them as untrusted input:
+
+- **Bound the input.** Cap expression length and reject obviously malformed input before parsing.
+- **Wrap parsing in `try`/`catch`.** Invalid expressions throw by design; an uncaught throw in a request handler is an availability bug in your service.
+- **Bound the iteration.** Date stepping is internally limited and throws rather than looping forever, but the amount of work you request is up to you - decide up front how many occurrences you will compute, and prefer bounded iteration with `endDate` over open-ended loops.
+- **Never build shell commands from parsed output.** This library gives you dates and field values, not a vetted command line.
+- **Keep the dependency current.** Watch releases and enable Dependabot or an equivalent so security releases reach you promptly.


### PR DESCRIPTION
## Description

Adds the two community health files GitHub's community profile checks for, and links them from the existing docs.

## Type of Change

- [x] Documentation update (changes to documentation only)

## Changes Made

- `SECURITY.md`: supported versions (`5.x` only, earlier majors end of life), private reporting through GitHub Security Advisories, coordinated disclosure, and a scope section written against this library's threat model rather than boilerplate: crafted expressions causing hangs or unbounded loops, ReDoS in the `validChars` regexes, prototype pollution via field values or crontab variables, `CronFileParser` path handling. Dependency issues and plain correctness or DST bugs are marked out of scope and routed elsewhere.
- `CODE_OF_CONDUCT.md`: Contributor Covenant 2.1, with enforcement routed to GitHub abuse reporting.
- `CONTRIBUTING.md`: replace the Code of Conduct placeholder paragraph with a link to the new file, add a security reporting section and TOC entry.
- `README.md`: link both files.

## Additional Notes

Private vulnerability reporting is already enabled on the repository, so the report link in `SECURITY.md` resolves today.

The response targets in `SECURITY.md` (5 business days to acknowledge, 14 days to assess) are self imposed and best effort, worth a second look before they are public.
