### PR TITLE
fix: drop day of month values the month does not have

### DIFF
--- a/src/CronExpressionParser.ts
+++ b/src/CronExpressionParser.ts
@@ -142,7 +142,7 @@ export class CronExpressionParser {
       second: new CronSecond(second, { rawValue: rawFields.second }),
       minute: new CronMinute(minute, { rawValue: rawFields.minute }),
       hour: new CronHour(hour, { rawValue: rawFields.hour }),
-      dayOfMonth: new CronDayOfMonth(dayOfMonth, { rawValue: rawFields.dayOfMonth }),
+      dayOfMonth: CronDayOfMonth.fromMonth(month, dayOfMonth, { rawValue: rawFields.dayOfMonth }),
       month: new CronMonth(month, { rawValue: rawFields.month }),
       dayOfWeek: new CronDayOfWeek(dayOfWeek, { rawValue: rawFields.dayOfWeek, nthDayOfWeek }),
     });

--- a/src/fields/CronDayOfMonth.ts
+++ b/src/fields/CronDayOfMonth.ts
@@ -1,5 +1,6 @@
 import { CronField, CronFieldOptions } from './CronField';
-import { CronChars, CronMax, CronMin, DayOfMonthRange } from './types';
+import { CronMonth } from './CronMonth';
+import { CronChars, CronMax, CronMin, DayOfMonthRange, MonthRange } from './types';
 
 const MIN_DAY = 1;
 const MAX_DAY = 31;
@@ -11,6 +12,23 @@ const DAY_CHARS = Object.freeze(['L']) as CronChars[];
  * @extends CronField
  */
 export class CronDayOfMonth extends CronField {
+  /**
+   * Creates a "day of the month" field limited to the days the given month has.
+   * @param {MonthRange[]} month - Values for the "month" field the days are used with
+   * @param {DayOfMonthRange[]} values - Values for the "day of the month" field
+   * @param {CronFieldOptions} [options] - Options provided by the parser
+   * @returns {CronDayOfMonth}
+   */
+  static fromMonth(month: MonthRange[], values: DayOfMonthRange[], options?: CronFieldOptions): CronDayOfMonth {
+    if (month.length !== 1) {
+      return new CronDayOfMonth(values, options);
+    }
+
+    const daysInMonth = CronMonth.daysInMonth[month[0] - 1];
+    const days = values.filter((value) => typeof value !== 'number' || value <= daysInMonth);
+    return new CronDayOfMonth(days.length > 0 ? days : values, options);
+  }
+
   static get min(): CronMin {
     return MIN_DAY;
   }

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -637,6 +637,38 @@ describe('CronExpressionParser', () => {
     }
   });
 
+  test('drops day of month values that the month cannot contain', () => {
+    const interval = CronExpressionParser.parse('0 0 16,31 6 *');
+    expect(interval.fields.dayOfMonth.values).toEqual([16]);
+  });
+
+  test('drops day of month values outside the month from a stepped range', () => {
+    const interval = CronExpressionParser.parse('0 0 16/5 6 *');
+    expect(interval.fields.dayOfMonth.values).toEqual([16, 21, 26]);
+  });
+
+  test('limits a wildcard day of month to the length of the month', () => {
+    const interval = CronExpressionParser.parse('0 0 * 2 *');
+    expect(interval.fields.dayOfMonth.values).toHaveLength(29);
+    expect(interval.fields.dayOfMonth.isWildcard).toEqual(true);
+  });
+
+  test('keeps day of month values when more than one month is given', () => {
+    const interval = CronExpressionParser.parse('0 0 31 1,6 *');
+    expect(interval.fields.dayOfMonth.values).toEqual([31]);
+  });
+
+  test('keeps the last day of month character when a single month is given', () => {
+    const interval = CronExpressionParser.parse('0 0 L 2 *');
+    expect(interval.fields.dayOfMonth.values).toEqual(['L']);
+  });
+
+  test('renders a stepped day of month in a single month to a stable expression', () => {
+    const rendered = CronExpressionParser.parse('* * 9-20/3 16-26/5 jun *').stringify(true);
+    expect(rendered).toEqual('* * 9-18/3 16/5 6 *');
+    expect(CronExpressionParser.parse(rendered).stringify(true)).toEqual(rendered);
+  });
+
   test('day of month and week are both set', () => {
     const interval = CronExpressionParser.parse('10 2 12 8 0');
     let next = interval.next();


### PR DESCRIPTION
## Description

`stringify()` is not idempotent for day of month when the month resolves to a single value. `* * 9-20/3 16-26/5 jun *` renders to `* * 9-18/3 16/5 6 *`, which renders again to `* * 9-18/3 16-31/5 6 *` before settling.

`stringifyField` narrows day of month to the length of the month, but `#parseRepeat` expands a bare start against the field's own maximum of 31, so `16/5` comes back as `[16, 21, 26, 31]`. The parser is the side at fault: 4.9.0 filtered days the month cannot have in `_handleMaxDaysInMonth`, and the TypeScript rewrite ported only the throw half of that function.

Fixes #425

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] All tests pass (`npm test`)
- [x] Code coverage is maintained or improved

Compared against the parent commit over 2184 expressions: no schedule changes, and no expression starts or stops throwing.

## Changes Made

- `CronDayOfMonth.fromMonth(month, values, options)` - builds the field from the month field and drops the days the month does not have. All values are kept when the month has none of them, so the existing check in `CronFieldCollection` still throws on `0 0 31 6 *` and still rescues `0 0 31 6 5`.
- `CronExpressionParser.parse` - uses the factory in place of the constructor.
- Six tests covering the drop, a stepped range, the wildcard case, several months, `L`, and idempotence.
