### PR TITLE
fix: keep day fields that cover their whole range out of the wildcard form

### DIFF
--- a/src/CronFieldCollection.ts
+++ b/src/CronFieldCollection.ts
@@ -323,6 +323,10 @@ export class CronFieldCollection {
       return null;
     }
     if (step === 1 && range.start === field.min && range.end && range.end >= max) {
+      const isDayField = field instanceof CronDayOfMonth || field instanceof CronDayOfWeek;
+      if (isDayField && !field.isWildcard) {
+        return null;
+      }
       return field.hasQuestionMarkChar ? '?' : '*';
     }
     if (step !== 1 && range.start === field.min && range.end && range.end >= max - step + 1) {

--- a/tests/CronExpression.test.ts
+++ b/tests/CronExpression.test.ts
@@ -361,7 +361,7 @@ describe('CronExpression', () => {
     });
 
     test('stringify cron expression with star range step', () => {
-      const expected = '0 */5 */2 * * *';
+      const expected = '0 */5 */2 1-31 * *';
       const interval = CronExpressionParser.parse('*/5 */2 */1 * *', {});
       let str = interval.stringify(true);
       expect(str).toEqual(expected);
@@ -406,7 +406,7 @@ describe('CronExpression', () => {
     });
 
     test('stringify cron expression with star range step (discard seconds)', () => {
-      const expected = '*/5 */2 * * *';
+      const expected = '*/5 */2 1-31 * *';
       const interval = CronExpressionParser.parse('*/5 */2 */1 * *', {});
       let str = interval.stringify();
       expect(str).toEqual(expected);
@@ -551,7 +551,6 @@ describe('CronExpression', () => {
     });
 
     test('stringify cron expression with extended day of week range (0,7)', () => {
-      const expected = '* * * * *';
       const interval = CronExpressionParser.parse('* * * * *');
 
       let str = CronExpression.fieldsToExpression(
@@ -564,7 +563,7 @@ describe('CronExpression', () => {
           dayOfWeek: new CronDayOfWeek([0, 1, 2, 3, 4, 5, 6]),
         }),
       ).stringify();
-      expect(str).toEqual(expected);
+      expect(str).toEqual('* * * * 0-6');
 
       str = CronExpression.fieldsToExpression(
         new CronFieldCollection({
@@ -576,7 +575,35 @@ describe('CronExpression', () => {
           dayOfWeek: new CronDayOfWeek([0, 1, 2, 3, 4, 5, 6, 7]),
         }),
       ).stringify();
-      expect(str).toEqual(expected);
+      expect(str).toEqual('* * * * *');
+    });
+
+    test('stringify day of week that covers the whole week without collapsing it', () => {
+      expect(CronExpressionParser.parse('0 0 16 * 0-6').stringify()).toEqual('0 0 16 * 0-6');
+      expect(CronExpressionParser.parse('0 0 16 * 0-7').stringify()).toEqual('0 0 16 * 0-6');
+      expect(CronExpressionParser.parse('0 0 16 * */1').stringify()).toEqual('0 0 16 * 0-6');
+    });
+
+    test('stringify day of month that covers the whole month without collapsing it', () => {
+      expect(CronExpressionParser.parse('0 0 1-31 * 5').stringify()).toEqual('0 0 1-31 * 5');
+    });
+
+    test('stringify day field written as a wildcard collapses it', () => {
+      expect(CronExpressionParser.parse('0 0 16 * *').stringify()).toEqual('0 0 16 * *');
+      expect(CronExpressionParser.parse('0 0 * * 5').stringify()).toEqual('0 0 * * 5');
+    });
+
+    test('stringify question mark day of week is unchanged', () => {
+      expect(CronExpressionParser.parse('0 0 16 * ?').stringify()).toEqual('0 0 16 * ?');
+    });
+
+    test('parsing an expression from its own rendered form keeps the schedule', () => {
+      const options = { currentDate: new Date('2026-01-01T00:00:00Z'), tz: 'UTC' };
+      const expression = CronExpressionParser.parse('0 0 16 * 0-6', options);
+      const reparsed = CronExpressionParser.parse(expression.stringify(), options);
+      expect(reparsed.take(5).map((date) => date.toISOString())).toEqual(
+        expression.take(5).map((date) => date.toISOString()),
+      );
     });
 
     test('throw validation error - missing field (seconds)', () => {


### PR DESCRIPTION
## Description

`stringifyField` renders a field as `*` whenever its values span the whole range, but day of month and day of week pick their matching rule from whether the field was written as a wildcard. Rendering `0-6` or `1-31` as `*` flips that rule, so an expression and its own rendering fire on different days.

`0 0 16 * 0-6` fires daily, its output `0 0 16 * *` fires on the 16th.

Fixes #424

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] All tests pass (`npm test`)
- [x] Code coverage is maintained or improved

## Changes Made

- `CronFieldCollection.#handleSingleRange` - a day field is only collapsed to `*` when it is a wildcard, otherwise it renders as a range. Other fields are unaffected.
- Five tests, three existing stringify expectations updated.

## Additional Notes

`stringify()` output changes for day fields covering their whole range. Schedules do not change.

| expression | before | after |
|---|---|---|
| `0 0 16 * 0-6` | `0 0 16 * *` | `0 0 16 * 0-6` |
| `0 0 16 * 0-7` | `0 0 16 * *` | `0 0 16 * 0-6` |
| `0 0 16 * */1` | `0 0 16 * *` | `0 0 16 * 0-6` |
| `0 0 1-31 * 5` | `0 0 * * 5` | `0 0 1-31 * 5` |
