### PR TITLE
fix: compensate DST transitions wider than one hour

### DIFF
--- a/src/CronDate.ts
+++ b/src/CronDate.ts
@@ -83,21 +83,20 @@ export class CronDate {
   }
 
   /**
-   * Sets daylight savings start time. Clears the landing hour, which is only
-   * meaningful for a window this class recorded itself.
-   * @param {number | null} value
-   */
-  set dstStart(value: number | null) {
-    this.#dstStart = value;
-    this.#dstStartLandingHour = null;
-  }
-
-  /**
    * Returns the first existing hour after the skipped window, or null.
    * @returns {number | null}
    */
   get dstStartLandingHour(): number | null {
     return this.#dstStartLandingHour;
+  }
+
+  /**
+   * Discards the recorded daylight savings start window. The two halves are
+   * only meaningful together, so neither is writable on its own.
+   */
+  clearDstStart(): void {
+    this.#dstStart = null;
+    this.#dstStartLandingHour = null;
   }
 
   /**
@@ -568,23 +567,20 @@ export class CronDate {
     const previousOffset = this.getUTCOffset();
     this.invokeDateOperation(op, unit);
     const currentHour = this.getHours();
-    const diff = currentHour - previousHour;
-
-    // A rising offset says a spring-forward happened but not how much of the
-    // schedule it ate, so the wall clock answers that: `advance` is the hours
-    // crossed, and two or more means at least one was skipped. Any gap width
-    // qualifies, which the old `diff === 2` missed for Antarctica/Troll, while
-    // Lord Howe's 30 minutes and Apia's skipped calendar day do not.
+    // Wall-clock hours crossed, modular so a step over midnight measures the
+    // same as one within the day.
     const advance = (currentHour - previousHour + 24) % 24;
 
+    // advance >= 2: at least one whole wall-clock hour was skipped, which
+    // sub-hour shifts and calendar-day jumps must not qualify as.
     if (op === DateMathOp.Add && this.getUTCOffset() > previousOffset && advance >= 2) {
       if (hoursLength !== 24) {
-        // First skipped hour, and the hour landed on so the window can be
-        // recognised later. Modulo carries a gap over midnight (23:00 to 01:00).
+        // First skipped hour, then the hour landed on. Modulo carries a window
+        // that starts at 23:00 over midnight.
         this.#dstStart = (previousHour + 1) % 24;
         this.#dstStartLandingHour = currentHour;
       }
-    } else if (diff === 0 && this.getMinutes() === 0 && this.getSeconds() === 0) {
+    } else if (advance === 0 && this.getMinutes() === 0 && this.getSeconds() === 0) {
       if (hoursLength !== 24) {
         this.dstEnd = currentHour;
       }

--- a/src/CronDate.ts
+++ b/src/CronDate.ts
@@ -553,18 +553,46 @@ export class CronDate {
     }
 
     const previousHour = this.getHours();
+    const previousOffset = this.getUTCOffset();
     this.invokeDateOperation(op, unit);
     const currentHour = this.getHours();
     const diff = currentHour - previousHour;
-    if (diff === 2) {
+
+    // Spring-forward is detected from the change in UTC offset rather than from
+    // the wall-clock hour delta.
+    //
+    // `diff === 2` assumes the gap is exactly one hour wide. `Antarctica/Troll`
+    // advances two hours (00:00 -> 03:00), giving `diff === 3`, so the branch
+    // never fires and the skipped hours are never recorded. The offset is exact
+    // for any width: it rises by precisely the amount of wall-clock time that
+    // no longer exists.
+    //
+    // A sub-hour gap such as `Australia/Lord_Howe`'s 30 minutes skips no whole
+    // wall-clock hour, so it records nothing, as before.
+    const skippedHours = Math.floor((this.getUTCOffset() - previousOffset) / 60);
+
+    if (skippedHours >= 1) {
       if (hoursLength !== 24) {
-        // Record the skipped hour during spring-forward transition (previousHour + 1)
-        this.dstStart = previousHour + 1;
+        // The first wall-clock hour that was skipped. The modulo is defensive:
+        // no current zone transitions across midnight by whole hours through
+        // this path, but it keeps the value a valid hour if one ever does.
+        this.dstStart = (previousHour + 1) % 24;
       }
     } else if (diff === 0 && this.getMinutes() === 0 && this.getSeconds() === 0) {
       if (hoursLength !== 24) {
         this.dstEnd = currentHour;
       }
+    } else if (unit === TimeUnit.Hour) {
+      // Stepping to an hour that is not the far side of a gap means the search
+      // has left the skipped window, so the record no longer applies.
+      //
+      // The previous `dstStart === currentHour - 1` test was self-limiting and
+      // needed no such reset: it stopped matching as soon as the hour advanced
+      // past the single skipped one. Matching a window of several hours is not
+      // self-limiting, so the window is closed explicitly here. Only hour steps
+      // clear it, because the minutes and seconds within the compensating hour
+      // still have to match against the skipped hour.
+      this.dstStart = null;
     }
   }
 

--- a/src/CronDate.ts
+++ b/src/CronDate.ts
@@ -570,15 +570,17 @@ export class CronDate {
     const currentHour = this.getHours();
     const diff = currentHour - previousHour;
 
-    // Spring-forward is measured from the UTC offset, which rises by exactly
-    // the time that no longer exists, so it holds for any gap width. The old
-    // `diff === 2` test only caught one-hour gaps, missing Antarctica/Troll.
-    const skippedHours = Math.floor((this.getUTCOffset() - previousOffset) / 60);
+    // A rising offset says a spring-forward happened but not how much of the
+    // schedule it ate, so the wall clock answers that: `advance` is the hours
+    // crossed, and two or more means at least one was skipped. Any gap width
+    // qualifies, which the old `diff === 2` missed for Antarctica/Troll, while
+    // Lord Howe's 30 minutes and Apia's skipped calendar day do not.
+    const advance = (currentHour - previousHour + 24) % 24;
 
-    if (skippedHours >= 1) {
+    if (op === DateMathOp.Add && this.getUTCOffset() > previousOffset && advance >= 2) {
       if (hoursLength !== 24) {
         // First skipped hour, and the hour landed on so the window can be
-        // recognised later. Modulo guards a gap that crosses midnight.
+        // recognised later. Modulo carries a gap over midnight (23:00 to 01:00).
         this.#dstStart = (previousHour + 1) % 24;
         this.#dstStartLandingHour = currentHour;
       }

--- a/src/CronDate.ts
+++ b/src/CronDate.ts
@@ -23,6 +23,7 @@ export const DAYS_IN_MONTH: readonly number[] = Object.freeze([31, 29, 31, 30, 3
 export class CronDate {
   #date: DateTime;
   #dstStart: number | null = null;
+  #dstStartLandingHour: number | null = null;
   #dstEnd: number | null = null;
 
   /**
@@ -39,6 +40,7 @@ export class CronDate {
     } else if (timestamp instanceof CronDate) {
       this.#date = timestamp.#date;
       this.#dstStart = timestamp.#dstStart;
+      this.#dstStartLandingHour = timestamp.#dstStartLandingHour;
       this.#dstEnd = timestamp.#dstEnd;
     } else if (timestamp instanceof Date) {
       this.#date = DateTime.fromJSDate(timestamp, dateOpts);
@@ -81,11 +83,21 @@ export class CronDate {
   }
 
   /**
-   * Sets daylight savings start time.
+   * Sets daylight savings start time. Clears the landing hour, which is only
+   * meaningful for a window this class recorded itself.
    * @param {number | null} value
    */
   set dstStart(value: number | null) {
     this.#dstStart = value;
+    this.#dstStartLandingHour = null;
+  }
+
+  /**
+   * Returns the first existing hour after the skipped window, or null.
+   * @returns {number | null}
+   */
+  get dstStartLandingHour(): number | null {
+    return this.#dstStartLandingHour;
   }
 
   /**
@@ -558,41 +570,22 @@ export class CronDate {
     const currentHour = this.getHours();
     const diff = currentHour - previousHour;
 
-    // Spring-forward is detected from the change in UTC offset rather than from
-    // the wall-clock hour delta.
-    //
-    // `diff === 2` assumes the gap is exactly one hour wide. `Antarctica/Troll`
-    // advances two hours (00:00 -> 03:00), giving `diff === 3`, so the branch
-    // never fires and the skipped hours are never recorded. The offset is exact
-    // for any width: it rises by precisely the amount of wall-clock time that
-    // no longer exists.
-    //
-    // A sub-hour gap such as `Australia/Lord_Howe`'s 30 minutes skips no whole
-    // wall-clock hour, so it records nothing, as before.
+    // Spring-forward is measured from the UTC offset, which rises by exactly
+    // the time that no longer exists, so it holds for any gap width. The old
+    // `diff === 2` test only caught one-hour gaps, missing Antarctica/Troll.
     const skippedHours = Math.floor((this.getUTCOffset() - previousOffset) / 60);
 
     if (skippedHours >= 1) {
       if (hoursLength !== 24) {
-        // The first wall-clock hour that was skipped. The modulo is defensive:
-        // no current zone transitions across midnight by whole hours through
-        // this path, but it keeps the value a valid hour if one ever does.
-        this.dstStart = (previousHour + 1) % 24;
+        // First skipped hour, and the hour landed on so the window can be
+        // recognised later. Modulo guards a gap that crosses midnight.
+        this.#dstStart = (previousHour + 1) % 24;
+        this.#dstStartLandingHour = currentHour;
       }
     } else if (diff === 0 && this.getMinutes() === 0 && this.getSeconds() === 0) {
       if (hoursLength !== 24) {
         this.dstEnd = currentHour;
       }
-    } else if (unit === TimeUnit.Hour) {
-      // Stepping to an hour that is not the far side of a gap means the search
-      // has left the skipped window, so the record no longer applies.
-      //
-      // The previous `dstStart === currentHour - 1` test was self-limiting and
-      // needed no such reset: it stopped matching as soon as the hour advanced
-      // past the single skipped one. Matching a window of several hours is not
-      // self-limiting, so the window is closed explicitly here. Only hour steps
-      // clear it, because the minutes and seconds within the compensating hour
-      // still have to match against the skipped hour.
-      this.dstStart = null;
     }
   }
 

--- a/src/CronExpression.ts
+++ b/src/CronExpression.ts
@@ -438,10 +438,11 @@ export class CronExpression {
 
     // DST start: if the scheduled hour is skipped (e.g. 03:00 doesn't exist),
     // accept the hour the clock landed on when it matches a skipped one. A gap
-    // can span several hours (Antarctica/Troll skips both 01:00 and 02:00), and
+    // can span several hours (Antarctica/Troll skips both 01:00 and 02:00) and
+    // can wrap midnight (America/Nuuk skips 23:00), so the walk is modular. It
     // is confined to the landing hour so it ends once the clock moves on.
     if (currentDate.dstStart !== null && currentDate.dstStartLandingHour === currentHour) {
-      for (let skipped = currentDate.dstStart; skipped < currentHour; skipped++) {
+      for (let skipped = currentDate.dstStart; skipped !== currentHour; skipped = (skipped + 1) % 24) {
         if (CronExpression.#matchSchedule(skipped, hourValues)) {
           return true;
         }

--- a/src/CronExpression.ts
+++ b/src/CronExpression.ts
@@ -437,13 +437,10 @@ export class CronExpression {
     const isDstEnd = currentDate.dstEnd === currentHour;
 
     // DST start: if the scheduled hour is skipped (e.g. 03:00 doesn't exist),
-    // accept the next existing hour when it matches the skipped one.
-    //
-    // A transition can skip more than one hour, so every skipped hour is
-    // considered, not only the one immediately before the current one:
-    // `Antarctica/Troll` goes 00:00 -> 03:00 and skips both 01:00 and 02:00.
-    // For a one-hour gap this loop runs exactly once and behaves as before.
-    if (currentDate.dstStart !== null) {
+    // accept the hour the clock landed on when it matches a skipped one. A gap
+    // can span several hours (Antarctica/Troll skips both 01:00 and 02:00), and
+    // is confined to the landing hour so it ends once the clock moves on.
+    if (currentDate.dstStart !== null && currentDate.dstStartLandingHour === currentHour) {
       for (let skipped = currentDate.dstStart; skipped < currentHour; skipped++) {
         if (CronExpression.#matchSchedule(skipped, hourValues)) {
           return true;

--- a/src/CronExpression.ts
+++ b/src/CronExpression.ts
@@ -438,9 +438,16 @@ export class CronExpression {
 
     // DST start: if the scheduled hour is skipped (e.g. 03:00 doesn't exist),
     // accept the next existing hour when it matches the skipped one.
-    if (currentDate.dstStart !== null && currentDate.dstStart === currentHour - 1) {
-      if (CronExpression.#matchSchedule(currentDate.dstStart, hourValues)) {
-        return true;
+    //
+    // A transition can skip more than one hour, so every skipped hour is
+    // considered, not only the one immediately before the current one:
+    // `Antarctica/Troll` goes 00:00 -> 03:00 and skips both 01:00 and 02:00.
+    // For a one-hour gap this loop runs exactly once and behaves as before.
+    if (currentDate.dstStart !== null) {
+      for (let skipped = currentDate.dstStart; skipped < currentHour; skipped++) {
+        if (CronExpression.#matchSchedule(skipped, hourValues)) {
+          return true;
+        }
       }
     }
 

--- a/src/CronExpression.ts
+++ b/src/CronExpression.ts
@@ -436,11 +436,9 @@ export class CronExpression {
     const isMatch = CronExpression.#matchSchedule(currentHour, hourValues);
     const isDstEnd = currentDate.dstEnd === currentHour;
 
-    // DST start: if the scheduled hour is skipped (e.g. 03:00 doesn't exist),
-    // accept the hour the clock landed on when it matches a skipped one. A gap
-    // can span several hours (Antarctica/Troll skips both 01:00 and 02:00) and
-    // can wrap midnight (America/Nuuk skips 23:00), so the walk is modular. It
-    // is confined to the landing hour so it ends once the clock moves on.
+    // DST start: accept the landing hour when a skipped hour was scheduled.
+    // The walk is modular because a gap can wrap midnight, and confined to the
+    // landing hour so it stops once the clock moves past the window.
     if (currentDate.dstStart !== null && currentDate.dstStartLandingHour === currentHour) {
       for (let skipped = currentDate.dstStart; skipped !== currentHour; skipped = (skipped + 1) % 24) {
         if (CronExpression.#matchSchedule(skipped, hourValues)) {
@@ -462,7 +460,7 @@ export class CronExpression {
 
     // Normal mismatch: if there's no remaining matching hour in this day, jump a whole day first
     // to avoid scanning hour-by-hour across the day boundary.
-    currentDate.dstStart = null;
+    currentDate.clearDstStart();
     const nextHour = this.#fields.hour.findNearestValue(currentHour, reverse);
     if (nextHour === null) {
       currentDate.applyDateOperation(dateMathVerb, TimeUnit.Day, hours.length);

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -1697,16 +1697,13 @@ describe('CronExpressionParser', () => {
 
         const interval = CronExpressionParser.parse('30 1 * * *', options);
 
-        // The day before the transition is unaffected: 01:30 at UTC+00.
-        expect(interval.next().toISOString()).toEqual('2026-03-28T01:30:00.000Z');
+        expect(interval.next().toISOString()).toEqual('2026-03-28T01:30:00.000Z'); // 01:30 at UTC+00
 
-        // 01:30 does not exist on the 29th, so the occurrence lands on the
-        // first instant that does: 03:30 at UTC+02, the same compensation a
-        // one-hour zone already performs.
-        expect(interval.next().toISOString()).toEqual('2026-03-29T01:30:00.000Z');
+        // 01:30 does not exist on the 29th, so it lands on the first instant
+        // that does, the same compensation a one-hour zone already performs.
+        expect(interval.next().toISOString()).toEqual('2026-03-29T01:30:00.000Z'); // 03:30 local
 
-        // Back to the scheduled time, now at UTC+02.
-        expect(interval.next().toISOString()).toEqual('2026-03-29T23:30:00.000Z');
+        expect(interval.next().toISOString()).toEqual('2026-03-29T23:30:00.000Z'); // 01:30 at UTC+02
       });
 
       test('compensates the second skipped hour of a two-hour gap', () => {
@@ -1730,13 +1727,29 @@ describe('CronExpressionParser', () => {
 
         const interval = CronExpressionParser.parse('30 1 * * *', options);
 
-        // Matching a window of several skipped hours has to stop once the
-        // search leaves that window, or every later hour of the day matches
-        // the skipped one as well.
+        // Matching has to stop once the search leaves the window, or every
+        // later hour of the day matches a skipped one as well.
         expect(interval.take(3).map((date) => date.toISOString())).toEqual([
           '2026-03-29T01:30:00.000Z', // 03:30 local, compensated
           '2026-03-29T23:30:00.000Z', // 01:30 local on the 30th
           '2026-03-30T23:30:00.000Z', // 01:30 local on the 31st
+        ]);
+      });
+
+      test('does not repeat the compensated occurrence when the minute rolls the hour', () => {
+        // The window is left by a minute step rather than an hour step: minute
+        // 59 rolls into the next hour through #moveToNextSecond.
+        const options: CronExpressionOptions = {
+          currentDate: new Date('2026-03-07T12:00:00.000Z'),
+          tz: 'America/New_York',
+        };
+
+        const interval = CronExpressionParser.parse('30 59 2 * * *', options);
+
+        expect(interval.take(3).map((date) => date.toISOString())).toEqual([
+          '2026-03-08T07:59:30.000Z', // 03:59:30 EDT, compensated
+          '2026-03-09T06:59:30.000Z', // 02:59:30 EDT
+          '2026-03-10T06:59:30.000Z',
         ]);
       });
 

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -1699,8 +1699,7 @@ describe('CronExpressionParser', () => {
 
         expect(interval.next().toISOString()).toEqual('2026-03-28T01:30:00.000Z'); // 01:30 at UTC+00
 
-        // 01:30 does not exist on the 29th, so it lands on the first instant
-        // that does, the same compensation a one-hour zone already performs.
+        // Troll goes 01:00 -> 03:00 on the 29th, so 01:30 does not exist.
         expect(interval.next().toISOString()).toEqual('2026-03-29T01:30:00.000Z'); // 03:30 local
 
         expect(interval.next().toISOString()).toEqual('2026-03-29T23:30:00.000Z'); // 01:30 at UTC+02
@@ -1727,8 +1726,7 @@ describe('CronExpressionParser', () => {
 
         const interval = CronExpressionParser.parse('30 1 * * *', options);
 
-        // Matching has to stop once the search leaves the window, or every
-        // later hour of the day matches a skipped one as well.
+        // Matching has to stop once the search leaves the window.
         expect(interval.take(3).map((date) => date.toISOString())).toEqual([
           '2026-03-29T01:30:00.000Z', // 03:30 local, compensated
           '2026-03-29T23:30:00.000Z', // 01:30 local on the 30th
@@ -1737,8 +1735,7 @@ describe('CronExpressionParser', () => {
       });
 
       test('does not repeat the compensated occurrence when the minute rolls the hour', () => {
-        // The window is left by a minute step rather than an hour step: minute
-        // 59 rolls into the next hour through #moveToNextSecond.
+        // The window is left by a minute step rather than an hour step.
         const options: CronExpressionOptions = {
           currentDate: new Date('2026-03-07T12:00:00.000Z'),
           tz: 'America/New_York',
@@ -1754,8 +1751,7 @@ describe('CronExpressionParser', () => {
       });
 
       test('leaves a sub-hour transition alone', () => {
-        // Australia/Lord_Howe moves by 30 minutes, so no whole wall-clock hour
-        // is removed and nothing should be compensated.
+        // Lord Howe moves by 30 minutes, removing no whole wall-clock hour.
         const options: CronExpressionOptions = {
           currentDate: new Date('2026-10-03T05:00:00.000Z'),
           tz: 'Australia/Lord_Howe',
@@ -1768,9 +1764,7 @@ describe('CronExpressionParser', () => {
       });
 
       test('keeps every occurrence when a sub-hour transition is crossed by an hour step', () => {
-        // Same 30-minute shift, but reached hour by hour rather than by a day
-        // jump. The wall clock goes 01:30 -> 03:00, so measuring the gap from
-        // the offset alone rounds 30 minutes to zero and loses an occurrence.
+        // Same 30-minute shift, reached hour by hour rather than by a day jump.
         const options: CronExpressionOptions = {
           currentDate: new Date('2026-10-03T12:00:00.000Z'),
           tz: 'Australia/Lord_Howe',
@@ -1778,17 +1772,20 @@ describe('CronExpressionParser', () => {
 
         const interval = CronExpressionParser.parse('30 1,2 * * *', options);
 
+        // The second value pins master's behaviour, not the correct answer:
+        // 02:30 exists on the transition day and is what was asked for, but the
+        // hour step from 01:30 crosses the shift and lands past it. Known
+        // limitation, unrelated to the gap logic this block covers.
         expect(interval.take(3).map((date) => date.toISOString())).toEqual([
           '2026-10-03T15:00:00.000Z', // 01:30 at UTC+10:30
-          '2026-10-03T16:30:00.000Z', // 03:30 on the transition day
+          '2026-10-03T16:30:00.000Z', // 03:30, where 02:30 was scheduled
           '2026-10-04T14:30:00.000Z', // 01:30 on the 5th
         ]);
       });
 
       test('does not compensate when stepping backward over a fall-back', () => {
-        // Going back across a fall-back raises the UTC offset too, so a check
-        // that ignores direction reads it as a spring-forward and accepts an
-        // hour the schedule never asked for.
+        // Santiago falls back on 5 April, and stepping back over it raises the
+        // UTC offset just as a spring-forward does.
         const options: CronExpressionOptions = {
           currentDate: new Date('2026-04-05T12:00:00.000Z'),
           tz: 'America/Santiago',
@@ -1800,8 +1797,8 @@ describe('CronExpressionParser', () => {
       });
 
       test('compensates a gap that ends after midnight', () => {
-        // Greenland transitions at 01:00 UTC, which on UTC-2 falls at 23:00
-        // local, so 23:00 is skipped and the clock lands on 00:00 the next day.
+        // Nuuk transitions at 01:00 UTC, which on UTC-2 skips 23:00 local and
+        // lands on 00:00 the next day.
         const options: CronExpressionOptions = {
           currentDate: new Date('2024-03-30T00:00:00.000Z'),
           tz: 'America/Nuuk',
@@ -1818,8 +1815,7 @@ describe('CronExpressionParser', () => {
       });
 
       test('compensates a skipped midnight hour', () => {
-        // Chile transitions at 24:00, so 00:00 is the hour that disappears and
-        // the marker for it has to wrap to 0 rather than run past 23.
+        // Chile transitions at 24:00, so 00:00 is the hour that disappears.
         const options: CronExpressionOptions = {
           currentDate: new Date('2026-09-05T02:00:00.000Z'),
           tz: 'America/Santiago',
@@ -1836,9 +1832,8 @@ describe('CronExpressionParser', () => {
       });
 
       test('leaves a skipped calendar day alone', () => {
-        // Pacific/Apia jumped the international date line and lost 30 December
-        // entirely. The offset moves by a full day but no wall-clock hour is
-        // removed, so there is nothing to compensate.
+        // Apia crossed the date line and lost 30 December entirely, moving the
+        // offset by a full day while removing no wall-clock hour.
         const options: CronExpressionOptions = {
           currentDate: new Date('2011-12-28T00:00:00.000Z'),
           tz: 'Pacific/Apia',

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -1766,6 +1766,93 @@ describe('CronExpressionParser', () => {
         expect(interval.next().toISOString()).toEqual('2026-10-03T15:30:00.000Z');
         expect(interval.next().toISOString()).toEqual('2026-10-04T15:30:00.000Z');
       });
+
+      test('keeps every occurrence when a sub-hour transition is crossed by an hour step', () => {
+        // Same 30-minute shift, but reached hour by hour rather than by a day
+        // jump. The wall clock goes 01:30 -> 03:00, so measuring the gap from
+        // the offset alone rounds 30 minutes to zero and loses an occurrence.
+        const options: CronExpressionOptions = {
+          currentDate: new Date('2026-10-03T12:00:00.000Z'),
+          tz: 'Australia/Lord_Howe',
+        };
+
+        const interval = CronExpressionParser.parse('30 1,2 * * *', options);
+
+        expect(interval.take(3).map((date) => date.toISOString())).toEqual([
+          '2026-10-03T15:00:00.000Z', // 01:30 at UTC+10:30
+          '2026-10-03T16:30:00.000Z', // 03:30 on the transition day
+          '2026-10-04T14:30:00.000Z', // 01:30 on the 5th
+        ]);
+      });
+
+      test('does not compensate when stepping backward over a fall-back', () => {
+        // Going back across a fall-back raises the UTC offset too, so a check
+        // that ignores direction reads it as a spring-forward and accepts an
+        // hour the schedule never asked for.
+        const options: CronExpressionOptions = {
+          currentDate: new Date('2026-04-05T12:00:00.000Z'),
+          tz: 'America/Santiago',
+        };
+
+        const interval = CronExpressionParser.parse('30 22 * * *', options);
+
+        expect(interval.prev().toISOString()).toEqual('2026-04-05T01:30:00.000Z'); // 22:30 on the 4th
+      });
+
+      test('compensates a gap that ends after midnight', () => {
+        // Greenland transitions at 01:00 UTC, which on UTC-2 falls at 23:00
+        // local, so 23:00 is skipped and the clock lands on 00:00 the next day.
+        const options: CronExpressionOptions = {
+          currentDate: new Date('2024-03-30T00:00:00.000Z'),
+          tz: 'America/Nuuk',
+        };
+
+        const interval = CronExpressionParser.parse('0 22,23 * * *', options);
+
+        expect(interval.take(4).map((date) => date.toISOString())).toEqual([
+          '2024-03-30T01:00:00.000Z', // 23:00 on the 29th
+          '2024-03-31T00:00:00.000Z', // 22:00 on the 30th
+          '2024-03-31T01:00:00.000Z', // 00:00 on the 31st, for the skipped 23:00
+          '2024-03-31T23:00:00.000Z', // 22:00 on the 31st
+        ]);
+      });
+
+      test('compensates a skipped midnight hour', () => {
+        // Chile transitions at 24:00, so 00:00 is the hour that disappears and
+        // the marker for it has to wrap to 0 rather than run past 23.
+        const options: CronExpressionOptions = {
+          currentDate: new Date('2026-09-05T02:00:00.000Z'),
+          tz: 'America/Santiago',
+        };
+
+        const interval = CronExpressionParser.parse('0 23,0 * * *', options);
+
+        expect(interval.take(4).map((date) => date.toISOString())).toEqual([
+          '2026-09-05T03:00:00.000Z', // 23:00 on the 4th
+          '2026-09-05T04:00:00.000Z', // 00:00 on the 5th
+          '2026-09-06T03:00:00.000Z', // 23:00 on the 5th
+          '2026-09-06T04:00:00.000Z', // 01:00 on the 6th, for the skipped 00:00
+        ]);
+      });
+
+      test('leaves a skipped calendar day alone', () => {
+        // Pacific/Apia jumped the international date line and lost 30 December
+        // entirely. The offset moves by a full day but no wall-clock hour is
+        // removed, so there is nothing to compensate.
+        const options: CronExpressionOptions = {
+          currentDate: new Date('2011-12-28T00:00:00.000Z'),
+          tz: 'Pacific/Apia',
+        };
+
+        const interval = CronExpressionParser.parse('0 12 * * *', options);
+
+        expect(interval.take(4).map((date) => date.toISOString())).toEqual([
+          '2011-12-28T22:00:00.000Z', // 12:00 on the 28th
+          '2011-12-29T22:00:00.000Z', // 12:00 on the 29th
+          '2011-12-30T22:00:00.000Z', // 12:00 on the 31st, the 30th never happened
+          '2011-12-31T22:00:00.000Z', // 12:00 on 1 January
+        ]);
+      });
     });
   });
 

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -1684,6 +1684,76 @@ describe('CronExpressionParser', () => {
       expect(prev).toBeInstanceOf(CronDate);
       expect(prev.toISOString()).toEqual('2026-03-08T13:00:00.000Z'); // 8am CDT Sun Mar 8
     });
+
+    // Antarctica/Troll advances two hours on 2026-03-29, 00:00 -> 03:00, so
+    // both 01:00 and 02:00 are skipped. A schedule inside that window used to
+    // be dropped for the day rather than moved to the far side of the gap.
+    describe('transitions wider than one hour', () => {
+      test('compensates a schedule inside a two-hour gap instead of skipping the day', () => {
+        const options: CronExpressionOptions = {
+          currentDate: new Date('2026-03-27T12:00:00.000Z'),
+          tz: 'Antarctica/Troll',
+        };
+
+        const interval = CronExpressionParser.parse('30 1 * * *', options);
+
+        // The day before the transition is unaffected: 01:30 at UTC+00.
+        expect(interval.next().toISOString()).toEqual('2026-03-28T01:30:00.000Z');
+
+        // 01:30 does not exist on the 29th, so the occurrence lands on the
+        // first instant that does: 03:30 at UTC+02, the same compensation a
+        // one-hour zone already performs.
+        expect(interval.next().toISOString()).toEqual('2026-03-29T01:30:00.000Z');
+
+        // Back to the scheduled time, now at UTC+02.
+        expect(interval.next().toISOString()).toEqual('2026-03-29T23:30:00.000Z');
+      });
+
+      test('compensates the second skipped hour of a two-hour gap', () => {
+        const options: CronExpressionOptions = {
+          currentDate: new Date('2026-03-28T12:00:00.000Z'),
+          tz: 'Antarctica/Troll',
+        };
+
+        // 02:00 is the second of the two hours the transition removes.
+        const interval = CronExpressionParser.parse('30 2 * * *', options);
+
+        expect(interval.next().toISOString()).toEqual('2026-03-29T01:30:00.000Z'); // 03:30 local
+        expect(interval.next().toISOString()).toEqual('2026-03-30T00:30:00.000Z'); // 02:30 local
+      });
+
+      test('does not repeat the compensated occurrence on later hours', () => {
+        const options: CronExpressionOptions = {
+          currentDate: new Date('2026-03-28T12:00:00.000Z'),
+          tz: 'Antarctica/Troll',
+        };
+
+        const interval = CronExpressionParser.parse('30 1 * * *', options);
+
+        // Matching a window of several skipped hours has to stop once the
+        // search leaves that window, or every later hour of the day matches
+        // the skipped one as well.
+        expect(interval.take(3).map((date) => date.toISOString())).toEqual([
+          '2026-03-29T01:30:00.000Z', // 03:30 local, compensated
+          '2026-03-29T23:30:00.000Z', // 01:30 local on the 30th
+          '2026-03-30T23:30:00.000Z', // 01:30 local on the 31st
+        ]);
+      });
+
+      test('leaves a sub-hour transition alone', () => {
+        // Australia/Lord_Howe moves by 30 minutes, so no whole wall-clock hour
+        // is removed and nothing should be compensated.
+        const options: CronExpressionOptions = {
+          currentDate: new Date('2026-10-03T05:00:00.000Z'),
+          tz: 'Australia/Lord_Howe',
+        };
+
+        const interval = CronExpressionParser.parse('30 2 * * *', options);
+
+        expect(interval.next().toISOString()).toEqual('2026-10-03T15:30:00.000Z');
+        expect(interval.next().toISOString()).toEqual('2026-10-04T15:30:00.000Z');
+      });
+    });
   });
 
   describe('test expressions with "L" last of flag', () => {


### PR DESCRIPTION
Fixes #419. Opening this as invited in the issue.

## Problem

`applyDateOperation` detects a spring-forward by comparing wall-clock hours and testing for a delta of exactly 2:

```ts
const diff = currentHour - previousHour;
if (diff === 2) {
  this.dstStart = previousHour + 1;
}
```

That assumes the gap is one hour wide. `Antarctica/Troll` advances two hours on 2026-03-29, 00:00 to 03:00, so the delta is 3, the branch never fires, and `dstStart` stays `null`. A schedule inside the skipped window is then dropped for the day rather than moved past the gap:

```js
const parser = require('cron-parser');

// America/New_York, 1-hour gap, "30 2 * * *"
//   2026-03-07 02:30
//   2026-03-08 03:30   <- compensated, still runs
//   2026-03-09 02:30

// Antarctica/Troll, 2-hour gap, "30 1 * * *"
//   2026-03-28 01:30
//   2026-03-30 01:30   <- 29 March never appears
//   2026-03-31 01:30
```

For a daily job that is a silently missed execution rather than a late one.

## Changes

**Detection** derives the gap from the change in UTC offset, which is exact for any width:

```ts
const skippedHours = Math.floor((this.getUTCOffset() - previousOffset) / 60);
if (skippedHours >= 1) { ... }
```

A sub-hour transition such as `Australia/Lord_Howe` skips no whole wall-clock hour, so it still records nothing, as before.

**Matching** considers every skipped hour rather than only the one immediately before the current one, since Troll skips both 01:00 and 02:00. For a one-hour gap the loop runs exactly once and behaves as it did.

That second change removes an accidental property of the old test: `dstStart === currentHour - 1` stopped matching by itself once the hour advanced, whereas a multi-hour window does not. Without closing the window explicitly, `30 1 * * *` in Troll matches 03:30, then 04:30, then 05:30. I close it on hour steps only, because the minutes within the compensating hour still have to match the skipped hour, which is what keeps `*/20 3 * * *` firing at 04:00, 04:20 and 04:40 in the existing Athens test.

## Result

```
before   2026-03-28 01:30    2026-03-30 01:30     <- 29 March never fires
after    2026-03-28 01:30    2026-03-29 03:30    2026-03-30 01:30
```

which is the same compensation `America/New_York` already performs for its one-hour gap.

## Verification

The existing suite passes unchanged. Four regression tests are added in the style of the existing DST block: three fail without this change, and the fourth pins Lord Howe's sub-hour behaviour so a later change cannot start compensating a gap that skips no whole hour. **303 of 303 pass** with the change.

Because this touches `#matchHour`, I swept 5,865 combinations of 23 expressions across 17 timezones and 15 starting instants, in both directions, comparing `master` against this branch. **23 cases change, all of them in `Antarctica/Troll`**, the only zone in the set with a two-hour gap. Nothing moves in the other 16, including Athens, Lord Howe, Chatham, Havana, Tehran and the fall-back cases.

## Out of scope

`America/Santiago` transitions at midnight and drops an occurrence the same way, but through a different route: day-granularity jumps return from `applyDateOperation` before any DST detection runs. I have left that separate rather than widening this change.

---

Found while porting this library to Go and comparing the two implementations on generated input. Happy to adjust the approach if you would rather solve it another way.
