### PR TITLE
fix: pad short expressions from the leading field slot

### DIFF
--- a/src/CronExpressionParser.ts
+++ b/src/CronExpressionParser.ts
@@ -174,9 +174,9 @@ export class CronExpressionParser {
     if (atoms.length > 6) {
       throw new Error('Invalid cron expression, too many fields');
     }
-    const defaults = ['*', '*', '*', '*', '*', '0'];
+    const defaults = ['0', '*', '*', '*', '*', '*'];
     if (atoms.length < defaults.length) {
-      atoms.unshift(...defaults.slice(atoms.length));
+      atoms.unshift(...defaults.slice(0, defaults.length - atoms.length));
     }
     const [second, minute, hour, dayOfMonth, month, dayOfWeek] = atoms;
     return { second, minute, hour, dayOfMonth, month, dayOfWeek };

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -617,8 +617,12 @@ describe('CronExpressionParser', () => {
     expect(interval.stringify(true)).toEqual('0 20 15 * * *');
   });
 
-  test('advances occurrences one minute apart instead of one second apart for a four field expression', () => {
-    const interval = CronExpressionParser.parse('20 15 * *');
+  test('advances occurrences one minute apart for a four field expression', () => {
+    const options = {
+      currentDate: new CronDate('Wed, 26 Dec 2012 14:38:00'),
+    };
+
+    const interval = CronExpressionParser.parse('20 15 * *', options);
     const first = interval.next();
     const second = interval.next();
     expect(second.getTime() - first.getTime()).toEqual(60000);

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -602,6 +602,28 @@ describe('CronExpressionParser', () => {
     }
   });
 
+  test('pads a four field expression with a zero second and a wildcard minute', () => {
+    const interval = CronExpressionParser.parse('20 15 * *');
+    expect(interval.stringify(true)).toEqual('0 * 20 15 * *');
+  });
+
+  test('pads a three field expression with a zero second and wildcard minutes and hours', () => {
+    const interval = CronExpressionParser.parse('15 * *');
+    expect(interval.stringify(true)).toEqual('0 * * 15 * *');
+  });
+
+  test('keeps five field expressions unchanged when padding', () => {
+    const interval = CronExpressionParser.parse('20 15 * * *');
+    expect(interval.stringify(true)).toEqual('0 20 15 * * *');
+  });
+
+  test('advances occurrences one minute apart instead of one second apart for a four field expression', () => {
+    const interval = CronExpressionParser.parse('20 15 * *');
+    const first = interval.next();
+    const second = interval.next();
+    expect(second.getTime() - first.getTime()).toEqual(60000);
+  });
+
   test('using explicit month definition and */5 day of month step', () => {
     const firstIterator = CronExpressionParser.parse('0 12 */5 6 *', {
       currentDate: '2019-06-01T11:00:00.000',


### PR DESCRIPTION
## Description

`#getRawFields` prepends `defaults.slice(atoms.length)` from `['*', '*', '*', '*', '*', '0']`, so the seconds default is taken last instead of first. With 5 fields only one value is prepended and it lands correctly, which is why standard cron is unaffected. With 4 or fewer the padded values end up in the wrong slots and `20 15 * *` fires every second.

Restores the v4 order (`parseDefaults = ['0', '*', '*', '*', '*', '*']`, read from the front).

Fixes #442

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] All tests pass (`npm test`)
- [x] Code coverage is maintained or improved

## Changes Made

- Reorder `defaults` to field order and take the leading slice in `#getRawFields`
- Add tests for 3-, 4- and 5-field padding, plus occurrence spacing on a 4-field expression

Affected inputs, verified against 4.9.0 (5- and 6-field output is byte-identical):

| input | before | after |
|---|---|---|
| `20 15 * *` | `* 0 20 15 * *` | `0 * 20 15 * *` |
| `15 * *` | `* * 0 15 * *` | `0 * * 15 * *` |
| `*` | throws `expected range 1-12` | `0 * * * * *` |
| `5 *` | throws `expected range 1-31` | `0 * * * 5 *` |

## Related Issues

- Fixes #442
- Related to #244
