### PR TITLE
fix: reject duplicate zero values in field validation

### DIFF
--- a/src/fields/CronField.ts
+++ b/src/fields/CronField.ts
@@ -243,7 +243,7 @@ export abstract class CronField {
     }
     // check for duplicate value in this.#values array
     const duplicate = this.#values.find((value, index) => this.#values.indexOf(value) !== index);
-    if (duplicate) {
+    if (duplicate !== undefined) {
       throw new Error(`${this.constructor.name} Validation error, duplicate values found: ${duplicate}`);
     }
   }

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -186,6 +186,44 @@ describe('CronExpressionParser', () => {
     test('empty expression in strict mode', () => {
       expect(() => CronExpressionParser.parse('', { strict: true })).toThrow();
     });
+
+    test('duplicated zero values are rejected', () => {
+      expect(() => CronExpressionParser.parse('0,0 0 0 1 1 0')).toThrow(
+        'CronSecond Validation error, duplicate values found: 0',
+      );
+      expect(() => CronExpressionParser.parse('0,0 * * * *')).toThrow(
+        'CronMinute Validation error, duplicate values found: 0',
+      );
+      expect(() => CronExpressionParser.parse('0 0,0 * * *')).toThrow(
+        'CronHour Validation error, duplicate values found: 0',
+      );
+      expect(() => CronExpressionParser.parse('0 0 * * 0,0')).toThrow(
+        'CronDayOfWeek Validation error, duplicate values found: 0',
+      );
+    });
+
+    test('listing both sunday spellings is rejected as a duplicate', () => {
+      expect(() => CronExpressionParser.parse('0 0 * * 0,7')).toThrow(
+        'CronDayOfWeek Validation error, duplicate values found: 0',
+      );
+      expect(() => CronExpressionParser.parse('0 0 * * 7,0')).toThrow(
+        'CronDayOfWeek Validation error, duplicate values found: 0',
+      );
+    });
+
+    test('lists that contain a single zero are accepted', () => {
+      expect(() => CronExpressionParser.parse('0,30 * * * *')).not.toThrow();
+      expect(() => CronExpressionParser.parse('0-5 * * * *')).not.toThrow();
+    });
+
+    test('expressions with duplicated zero values fail at parse instead of crashing stringify', () => {
+      expect(() => CronExpressionParser.parse('0,0,0 * * * *')).toThrow(
+        'CronMinute Validation error, duplicate values found: 0',
+      );
+      expect(() => CronExpressionParser.parse('0 0 * * 0,0,0')).toThrow(
+        'CronDayOfWeek Validation error, duplicate values found: 0',
+      );
+    });
   });
 
   describe('take multiple dates', () => {

--- a/tests/CronField.test.ts
+++ b/tests/CronField.test.ts
@@ -1,4 +1,4 @@
-import { CronDayOfWeek, CronField, CronSecond, DayOfWeekRange, SixtyRange } from '../src';
+import { CronDayOfWeek, CronField, CronHour, CronMinute, CronSecond, DayOfWeekRange, SixtyRange } from '../src';
 
 describe('CronField', () => {
   describe('wildcard detection', () => {
@@ -33,6 +33,19 @@ describe('CronField', () => {
 
     test('should throw an error when duplicate value is provided as a range', () => {
       expect(() => new CronSecond([0, 59, 59])).toThrow('CronSecond Validation error, duplicate values found: 59');
+    });
+
+    test('should throw an error when the duplicated value is zero', () => {
+      expect(() => new CronSecond([0, 0])).toThrow('CronSecond Validation error, duplicate values found: 0');
+      expect(() => new CronMinute([0, 0])).toThrow('CronMinute Validation error, duplicate values found: 0');
+      expect(() => new CronHour([0, 0])).toThrow('CronHour Validation error, duplicate values found: 0');
+      expect(() => new CronDayOfWeek([0, 0])).toThrow('CronDayOfWeek Validation error, duplicate values found: 0');
+    });
+
+    test('should not throw an error when a non-duplicate set contains zero', () => {
+      expect(() => new CronSecond([0, 1])).not.toThrow();
+      expect(() => new CronMinute([0, 30])).not.toThrow();
+      expect(new CronDayOfWeek([0, 7]).values).toEqual([0, 7]);
     });
 
     test('should not reorder the values array provided by the caller', () => {


### PR DESCRIPTION
## Description

`CronField.validate()` finds duplicates with `Array.prototype.find`, which returns the duplicated value itself. When that value is `0`, the truthiness check `if (duplicate)` skips the throw, so `0,0` was accepted while `1,1` was rejected in the same field. Every field whose minimum is 0 is affected (second, minute, hour, day of week). An accepted duplicate zero also produces a zero range step in `stringify()`, which crashes with `Unexpected range step` on an expression the parser accepted (`CronExpressionParser.parse('0,0,0 * * * *').stringify()`).

Changes the check to `duplicate !== undefined`.

Day of week: `0` and `7` both denote Sunday and the parser maps both to `0`, so listing Sunday twice now throws like any other duplicate. Non-zero duplicates (`1,1`, `1,1-3`) have always been rejected in v5; zero was the only value exempt.

Affected inputs:

| input | before | after |
|---|---|---|
| `0,0 * * * *` | parses, values `[0,0]` | throws `duplicate values found: 0` |
| `0,0,0 * * * *` | parses; `stringify()` throws `Unexpected range step` | throws at parse |
| `0 0 * * 0,7` | parses, values `[0,0]` | throws |
| `0 0 * * 0,5-7` | parses, values `[0,0,5,6,7]` | throws |
| `new CronSecond([0, 0])` | accepted | throws |
| `0 0 * * 5-7` | parses, values `[0,5,6,7]` | unchanged |

Supersedes #418 by @gaoflow - carries over its `CronField` fix and test coverage, without the parser-level Sunday alias tracking (see the review discussion there).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] All tests pass (`npm test`)
- [x] Code coverage is maintained or improved

## Changes Made

- `CronField.validate()`: check the duplicate lookup result against `undefined` instead of relying on truthiness
- Add tests for duplicate zero rejection via direct construction and via `parse()` for all four zero-min fields, both Sunday spellings listed together, and the `stringify()` crash regression

## Related Issues

- Fixes #423
- Supersedes #418
