### PR TITLE
fix: emit a fall-back DST repeated hour only once from prev()

### DIFF
--- a/src/CronDate.ts
+++ b/src/CronDate.ts
@@ -340,6 +340,20 @@ export class CronDate {
   }
 
   /**
+   * Returns true when this instant is the second (later) occurrence of an ambiguous
+   * local hour produced by a fall-back DST transition, i.e. the repeated hour.
+   *
+   * The real hour before this one lands on the same wall-clock hour but at a larger
+   * UTC offset, which is only possible on the later pass of a repeated hour.
+   *
+   * @returns {boolean} True when this is the repeated (second) pass of a fall-back hour.
+   */
+  isSecondPassOfRepeatedHour(): boolean {
+    const oneHourEarlier = this.#date.minus({ hours: 1 });
+    return oneHourEarlier.hour === this.#date.hour && oneHourEarlier.offset > this.#date.offset;
+  }
+
+  /**
    * Sets the time to the start of the day (00:00:00.000) in the current timezone.
    */
   setStartOfDay(): void {

--- a/src/CronExpression.ts
+++ b/src/CronExpression.ts
@@ -454,6 +454,17 @@ export class CronExpression {
       return false;
     }
 
+    // DST end: avoid returning the repeated hour twice when searching backward.
+    // Iterating in reverse meets the later pass of the repeated hour first; skip it so
+    // prev() keeps only the earlier pass, matching next()'s forward de-duplication. The
+    // wildcard hour (24 values) intentionally keeps both passes in both directions.
+    if (reverse && isMatch && hours.length !== 24 && currentDate.isSecondPassOfRepeatedHour()) {
+      currentDate.applyDateOperation(DateMathOp.Subtract, TimeUnit.Hour, hours.length);
+      currentDate.setMinutes(this.#getMinOrMax(this.#fields.minute.values as number[], reverse));
+      currentDate.setSeconds(this.#getMinOrMax(this.#fields.second.values as number[], reverse));
+      return false;
+    }
+
     if (isMatch) {
       return true;
     }

--- a/tests/CronExpressionParser.test.ts
+++ b/tests/CronExpressionParser.test.ts
@@ -1472,6 +1472,62 @@ describe('CronExpressionParser', () => {
       expect(next.getDate()).toEqual(31);
     });
 
+    test('prev() de-duplicates the repeated DST end hour like next() - 0 3 * * *', () => {
+      const options: CronExpressionOptions = {
+        currentDate: '2016-10-31 00:00:00',
+        endDate: undefined,
+        tz: 'Europe/Athens',
+      };
+
+      const interval: CronExpression = CronExpressionParser.parse('0 3 * * *', options);
+      let prev: CronDate;
+
+      expect(interval).toBeTruthy();
+
+      // The repeated 03:00 hour (fall-back) must be returned only once on the 30th.
+      prev = interval.prev();
+      expect(prev.getHours()).toEqual(3);
+      expect(prev.getDate()).toEqual(30);
+
+      prev = interval.prev();
+      expect(prev.getHours()).toEqual(3);
+      expect(prev.getDate()).toEqual(29);
+    });
+
+    test('prev() de-duplicates the repeated DST end hour like next() - */20 3 * * *', () => {
+      const options: CronExpressionOptions = {
+        currentDate: '2016-10-31 00:00:00',
+        endDate: undefined,
+        tz: 'Europe/Athens',
+      };
+
+      const interval: CronExpression = CronExpressionParser.parse('*/20 3 * * *', options);
+      let prev: CronDate;
+
+      expect(interval).toBeTruthy();
+
+      prev = interval.prev();
+      expect(prev.getMinutes()).toEqual(40);
+      expect(prev.getHours()).toEqual(3);
+      expect(prev.getDate()).toEqual(30);
+
+      prev = interval.prev();
+      expect(prev.getMinutes()).toEqual(20);
+      expect(prev.getHours()).toEqual(3);
+      expect(prev.getDate()).toEqual(30);
+
+      prev = interval.prev();
+      expect(prev.getMinutes()).toEqual(0);
+      expect(prev.getHours()).toEqual(3);
+      expect(prev.getDate()).toEqual(30);
+
+      // Must move to the previous day rather than repeating the fall-back hour.
+      prev = interval.prev();
+      expect(prev.getMinutes()).toEqual(40);
+      expect(prev.getHours()).toEqual(3);
+      expect(prev.getDate()).toEqual(29);
+    });
+
     test('works on DST end 2016-10-30 00:00:01 - 0 * 30 * *', () => {
       const options: CronExpressionOptions = {
         currentDate: '2016-10-30 00:00:01',


### PR DESCRIPTION
On a fall-back DST transition the local clock repeats an hour (e.g. `America/New_York`, 2025-11-02, 01:00–01:59 occurs twice). For a restricted-hour schedule, `next()` de-duplicates the repeated hour and fires it once, but `prev()` had no reverse-direction equivalent, so it returned **both** passes:

```js
const i = CronExpressionParser.parse('0 30 1 * * *', {
  tz: 'America/New_York',
  currentDate: '2025-11-02T02:00:00.000-05:00',
});
i.prev().toISOString(); // 2025-11-02T06:30:00.000Z  (01:30 EST, later pass)
i.prev().toISOString(); // 2025-11-02T05:30:00.000Z  (01:30 EDT, earlier pass)
```

`next()` firing the repeated hour once is pinned by the existing `Europe/Athens` DST-end tests (`works on DST end 2016-10-30 - 0 3 * * *`), so `prev()` emitting it twice — and `includesDate()` returning `true` for both instants — is the defect.

## The fix

- `CronDate#isSecondPassOfRepeatedHour()` detects the later pass of an ambiguous fall-back hour (the previous real hour has the same wall-clock hour but a larger UTC offset).
- `#matchHour` gains a reverse-direction skip that mirrors the existing forward de-duplication, so `prev()` keeps only the earlier pass.

The wildcard hour (`*`, 24 values) intentionally keeps both passes in both directions, preserved via a `hours.length !== 24` guard.

## Scope

This is distinct from #378, which is a *spring-forward* `prev()` skip (a different transition and the opposite symptom); this change does not address that issue.

## Tests

Two regression tests mirroring the existing Athens forward-direction tests; they fail without the fix and pass with it. Full suite: `339/339` passing, 100% coverage on both changed files, lint + types clean.
